### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         otp: ["27.x", "28.x"]
-        elixir: ["1.18", "1.19"]
+        elixir: ["1.19"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds a CI workflow that runs on pushes and PRs to `main`
- Tests across a matrix of OTP (27, 28) and Elixir (1.19)
- Checks compilation with `--warnings-as-errors`, formatting, and tests
- Caches `deps` and `_build` per OTP/Elixir version