### PR TITLE
Add child_spec/1 to use Parley macro

### DIFF
--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -42,6 +42,14 @@ defmodule Parley do
       Parley.send_frame(MyClient, {:text, "hello"})
       Parley.disconnect(MyClient)
 
+  ### Starting under a supervisor
+
+      children = [
+        {MyClient, {%{}, url: "wss://example.com/ws", name: MyClient}}
+      ]
+
+      Supervisor.start_link(children, strategy: :one_for_one)
+
   ## Name registration
 
   The `:name` option supports the same values as `GenServer`:
@@ -86,6 +94,15 @@ defmodule Parley do
       def handle_disconnect(_reason, state), do: {:ok, state}
 
       defoverridable handle_connect: 1, handle_frame: 2, handle_disconnect: 2
+
+      def child_spec({init_arg, opts}) do
+        %{
+          id: __MODULE__,
+          start: {__MODULE__, :start_link, [init_arg, opts]}
+        }
+      end
+
+      defoverridable child_spec: 1
 
       def start_link(init_arg, opts \\ []) do
         Parley.start_link(__MODULE__, init_arg, opts)


### PR DESCRIPTION
## Summary

- Adds `child_spec/1` to the `use Parley` macro, enabling standard supervisor integration
- Makes `child_spec/1` overridable so users can customize it
- Documents supervision tree usage in module docs

## Usage

```elixir
children = [
  {MyClient, {%{}, url: "wss://example.com/ws", name: MyClient}}
]

Supervisor.start_link(children, strategy: :one_for_one)
```

## Test plan

- [x] Returns valid child spec with correct id and start tuple
- [x] Process starts and works under a Supervisor
- [x] `child_spec/1` is overridable

Closes #15