### PR TITLE
Handle connect_error internal event in disconnected state

### DIFF
--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -53,6 +53,10 @@ defmodule Parley.Connection do
      }}
   end
 
+  def disconnected(:internal, {:connect_error, reason}, data) do
+    {:stop, {:error, reason}, data}
+  end
+
   def disconnected(:internal, :connect, data) do
     %{uri: uri} = data
 


### PR DESCRIPTION
## Why

The `:connecting` and `:connected` states emit `{:next_event, :internal, {:connect_error, reason}}` when transitioning back to `:disconnected`, but there was no clause in `disconnected/3` to handle this event. This caused the process to crash with a function clause error instead of stopping gracefully.

## This change addresses the need by:

- Adding a `disconnected(:internal, {:connect_error, reason}, data)` clause that stops the process with `{:error, reason}`
- Adding a test for unreachable host (initial connection failure)
- Adding a test for server-initiated disconnect that exercises the `connect_error` path

Closes #8