### PR TITLE
Handle close frames properly

### DIFF
--- a/test/support/echo_server.ex
+++ b/test/support/echo_server.ex
@@ -9,6 +9,10 @@ defmodule Parley.Test.EchoServer do
     def init(_opts), do: {:ok, %{}}
 
     @impl true
+    def handle_in({"close", [opcode: :text]}, state) do
+      {:stop, :normal, {1000, "normal closure"}, state}
+    end
+
     def handle_in({message, [opcode: :text]}, state) do
       {:reply, :ok, [{:text, message}], state}
     end


### PR DESCRIPTION
## Why

Server-initiated close frames were silently swallowed in `process_frames/2`. This meant `handle_disconnect` was never called when the server gracefully closed the WebSocket connection, leaving users with no visibility into server-initiated disconnects.

## This change addresses the need by:

- Completing the WebSocket close handshake (sending a close frame back to the server)
- Transitioning to `:disconnected` state with the close reason
- Passing `{:remote_close, code, reason}` to `handle_disconnect` so users can distinguish server-initiated closes from other disconnects
- Adding a `disconnect_reason` field to the connection data struct, used by the enter callback instead of hardcoding `:closed`
- Adding echo server support for triggering server-initiated close in tests

Closes #11