### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 João Pereira
+Copyright (c) 2026 João Silva
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Why:

A LICENSE file is required for open-source publishing and Hex package compliance.

## This change addresses the need by:

- Adding the MIT License file with copyright attributed to João Pereira

Closes #17