### PR TITLE
Enrich callback return types with push and stop

### DIFF
--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -71,11 +71,30 @@ defmodule Parley do
   @type state :: term()
   @type frame :: {:text, String.t()} | {:binary, binary()} | {:ping, binary()} | {:pong, binary()}
 
-  @doc "Called when the WebSocket handshake completes."
-  @callback handle_connect(state) :: {:ok, state}
+  @doc """
+  Called when the WebSocket handshake completes.
 
-  @doc "Called when a frame is received from the server."
-  @callback handle_frame(frame, state) :: {:ok, state}
+  ## Return values
+
+    * `{:ok, state}` — update state, remain connected
+    * `{:push, frame, state}` — send a frame immediately after connecting
+      (useful for auth or subscribe messages)
+    * `{:stop, reason, state}` — reject the connection, stop the process
+  """
+  @callback handle_connect(state) ::
+              {:ok, state} | {:push, frame, state} | {:stop, reason :: term(), state}
+
+  @doc """
+  Called when a frame is received from the server.
+
+  ## Return values
+
+    * `{:ok, state}` — update state
+    * `{:push, frame, state}` — send a frame back to the server
+    * `{:stop, reason, state}` — close the connection and stop the process
+  """
+  @callback handle_frame(frame, state) ::
+              {:ok, state} | {:push, frame, state} | {:stop, reason :: term(), state}
 
   @doc "Called when the connection is lost or closed."
   @callback handle_disconnect(reason :: term(), state) :: {:ok, state}


### PR DESCRIPTION
## Why:

Callbacks only returned `{:ok, state}`, limiting what users could do from
within callbacks. Common patterns like sending a frame on connect (auth/subscribe)
or stopping on a specific frame required workarounds outside the callback model.

## This change addresses the need by:

- Adding `{:push, frame, state}` return to `handle_connect` and `handle_frame`
  for sending frames directly from callbacks
- Adding `{:stop, reason, state}` return to `handle_connect` and `handle_frame`
  for stopping the process from callbacks
- Adding `send_frame_internal/2` helper for encoding and sending frames inline
- Fixing a bug where `send_frame_internal`, `send_close`, and `send_pong`
  discarded updated Mint conn/websocket state on error
- Adding 4 tests covering push-on-connect, stop-on-connect, push-on-frame,
  and stop-on-frame

Closes #14