### PR TITLE
Add release workflow for Hex publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "27.x"
+          otp-version: "28.x"
           elixir-version: "1.19"
 
       - name: Install dependencies


### PR DESCRIPTION
## Why:

There is no automated way to publish the package to Hex.pm. Publishing manually
is error-prone and easy to forget.

## This change addresses the need by:

- Adding a separate `.github/workflows/release.yml` workflow triggered on GitHub release published events
- The workflow installs dependencies and runs `mix hex.publish --yes` using the `HEX_API_KEY` secret
- Kept separate from CI to avoid matrix duplication issues and maintain clean separation of concerns
- CI validation is expected to happen via branch protection on main, so the release workflow focuses solely on publishing

**Note:** Requires adding a `HEX_API_KEY` secret to the repository settings before the first release.