### PR TITLE
Handle stale TCP messages in disconnected state

### DIFF
--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -84,6 +84,10 @@ defmodule Parley.Connection do
     end
   end
 
+  def disconnected(:info, _message, _data) do
+    :keep_state_and_data
+  end
+
   def disconnected({:call, from}, {:send, _frame}, _data) do
     {:keep_state_and_data, [{:reply, from, {:error, :disconnected}}]}
   end


### PR DESCRIPTION
## Why:

After `disconnect/1` sends a close frame and transitions to `:disconnected`, the server's close frame response can arrive as a TCP message. There was no `disconnected(:info, ...)` handler, causing a `FunctionClauseError` crash. This is a race condition that appears intermittently depending on timing.

## This change addresses the need by:

- Adding a catch-all `disconnected(:info, _message, _data)` clause that returns `:keep_state_and_data`, safely ignoring stale TCP messages that arrive after the connection is closed