### PR TITLE
Add handle_ping/2 callback (#32)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Parley provides a callback-based API (`use Parley`) backed by a `gen_statem` sta
 @callback init(init_arg) :: {:ok, state} | {:stop, reason}
 @callback handle_connect(state) :: {:ok, state} | {:push, frame, state} | {:stop, reason, state}
 @callback handle_frame(frame, state) :: {:ok, state} | {:push, frame, state} | {:stop, reason, state}
+@callback handle_ping(payload, state) :: {:ok, state} | {:push, frame, state} | {:stop, reason, state}
 @callback handle_info(message, state) :: {:ok, state} | {:push, frame, state} | {:stop, reason, state}
 @callback handle_disconnect(reason, state) :: {:ok, state}
 ```

--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -117,10 +117,11 @@ defmodule Parley do
       Transforms the `init_arg` into user state (default: passes it through)
     * `c:handle_connect/1` — called when the WebSocket handshake completes
     * `c:handle_frame/2` — called when a frame is received from the server
+    * `c:handle_ping/2` — called when a ping frame is received (pong is sent automatically)
     * `c:handle_info/2` — called when the process receives a non-WebSocket message
     * `c:handle_disconnect/2` — called when the connection is lost or closed
 
-  `c:handle_connect/1`, `c:handle_frame/2`, and `c:handle_info/2` also support
+  `c:handle_connect/1`, `c:handle_frame/2`, `c:handle_ping/2`, and `c:handle_info/2` also support
   `{:push, frame, state}` to send a frame from within the callback, and
   `{:stop, reason, state}` to stop the process. See the callback docs for details.
   """
@@ -169,6 +170,24 @@ defmodule Parley do
   """
   @callback handle_frame(frame, state) ::
               {:ok, state} | {:push, frame, state} | {:stop, reason :: term(), state}
+
+  @doc """
+  Called when a ping frame is received.
+
+  The pong response is always sent automatically before this callback is
+  invoked, so the WebSocket protocol is never violated. Use this callback
+  to observe pings for heartbeat monitoring, latency tracking, or logging.
+
+  Supported return values:
+
+    * `{:ok, state}` — continue with updated state
+    * `{:push, frame, state}` — send a frame and continue
+    * `{:stop, reason, state}` — gracefully stop the connection
+  """
+  @callback handle_ping(payload :: binary(), state) ::
+              {:ok, state}
+              | {:push, frame, state}
+              | {:stop, reason :: term(), state}
 
   @doc """
   Called when the process receives a message that is not a WebSocket frame.
@@ -221,6 +240,9 @@ defmodule Parley do
       def handle_frame(_frame, state), do: {:ok, state}
 
       @impl true
+      def handle_ping(_payload, state), do: {:ok, state}
+
+      @impl true
       def handle_info(_message, state), do: {:ok, state}
 
       @impl true
@@ -229,6 +251,7 @@ defmodule Parley do
       defoverridable init: 1,
                      handle_connect: 1,
                      handle_frame: 2,
+                     handle_ping: 2,
                      handle_info: 2,
                      handle_disconnect: 2
 

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -340,7 +340,8 @@ defmodule Parley.Connection do
         {:halt, {:close, code, reason, data}}
 
       {:ping, payload}, {:ok, data} ->
-        {:cont, {:ok, send_pong(data, payload)}}
+        data = send_pong(data, payload)
+        handle_frame_result(data.module.handle_ping(payload, data.user_state), data)
 
       frame, {:ok, data} ->
         handle_frame_result(data.module.handle_frame(frame, data.user_state), data)

--- a/test/parley_test.exs
+++ b/test/parley_test.exs
@@ -656,6 +656,126 @@ defmodule ParleyTest do
     end
   end
 
+  describe "handle_ping/2" do
+    test "default implementation keeps connection alive", %{url: url} do
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      # Trigger a server-sent ping
+      :ok = Parley.send_frame(pid, {:text, "send_ping"})
+
+      # Connection stays alive — verify by sending another message
+      :ok = Parley.send_frame(pid, {:text, "still alive"})
+      assert_receive {:frame, {:text, "still alive"}}, 1000
+
+      Parley.disconnect(pid)
+    end
+
+    test "receives ping payload for observation", %{url: url} do
+      defmodule PingObserverClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_ping(payload, %{test_pid: pid} = state) do
+          send(pid, {:ping_received, payload})
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_frame(frame, %{test_pid: pid} = state) do
+          send(pid, {:frame, frame})
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} = Parley.start_link(PingObserverClient, %{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      :ok = Parley.send_frame(pid, {:text, "send_ping:hello"})
+      assert_receive {:ping_received, "hello"}, 1000
+
+      Parley.disconnect(pid)
+    end
+
+    test "returning {:push, frame, state} sends a frame", %{url: url} do
+      defmodule PingPushClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_ping(_payload, state) do
+          {:push, {:text, "got_ping"}, state}
+        end
+
+        @impl true
+        def handle_frame(frame, %{test_pid: pid} = state) do
+          send(pid, {:frame, frame})
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} = Parley.start_link(PingPushClient, %{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      :ok = Parley.send_frame(pid, {:text, "send_ping"})
+      # The echo server echoes back the text frame pushed by handle_ping
+      assert_receive {:frame, {:text, "got_ping"}}, 1000
+
+      Parley.disconnect(pid)
+    end
+
+    test "returning {:stop, reason, state} stops the process", %{url: url} do
+      defmodule PingStopClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_ping(_payload, state) do
+          {:stop, :ping_stop, state}
+        end
+
+        @impl true
+        def handle_frame(_frame, state), do: {:ok, state}
+      end
+
+      Process.flag(:trap_exit, true)
+
+      {:ok, pid} = Parley.start_link(PingStopClient, %{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      :ok = Parley.send_frame(pid, {:text, "send_ping"})
+      assert_receive {:EXIT, ^pid, :ping_stop}, 1000
+    end
+  end
+
   describe "connection options" do
     test "headers are sent during WebSocket upgrade", %{port: port} do
       {:ok, pid} =

--- a/test/support/echo_server.ex
+++ b/test/support/echo_server.ex
@@ -22,6 +22,14 @@ defmodule Parley.Test.EchoServer do
       {:reply, :ok, [{:text, "push_this"}], state}
     end
 
+    def handle_in({"send_ping", [opcode: :text]}, state) do
+      {:push, {:ping, "ping"}, state}
+    end
+
+    def handle_in({"send_ping:" <> payload, [opcode: :text]}, state) do
+      {:push, {:ping, payload}, state}
+    end
+
     def handle_in({message, [opcode: :text]}, state) do
       {:reply, :ok, [{:text, message}], state}
     end


### PR DESCRIPTION
## Why

Closes #32

Parley automatically responds to WebSocket ping frames with pong, but provides no way for users to observe those pings. This makes it impossible to implement heartbeat monitoring, latency tracking, or ping-related logging without dropping down to raw frame handling.

## This change addresses the need by

- Adding `@callback handle_ping(payload, state)` to the `Parley` behaviour, placed after `handle_frame/2`, with the same return types (`{:ok, state}`, `{:push, frame, state}`, `{:stop, reason, state}`)
- Updating `process_frames/2` in `Parley.Connection` to invoke `handle_ping/2` after the automatic pong reply, so the protocol is never violated
- Providing a default no-op implementation (`{:ok, state}`) via the `__using__` macro, keeping the callback fully optional and backward-compatible
- Adding ping-sending handlers to the echo server test support module
- Adding four tests covering default behavior, payload observation, push-on-ping, and stop-on-ping
- Updating `AGENTS.md` and the `@moduledoc` callback summary to include `handle_ping/2`