### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add `parley` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:parley, "~> 0.1.0"}
+    {:parley, "~> 0.2.0"}
   ]
 end
 ```
@@ -62,9 +62,12 @@ Parley.disconnect(pid)
 
 - `:url` (required) — the WebSocket URL to connect to (`ws://` or `wss://`)
 - `:name` — an optional name for the process (passed to `:gen_statem`)
+- `:headers` — custom headers sent with the WebSocket upgrade request (e.g. `[{"authorization", "Bearer token"}]`)
 - `:connect_timeout` — timeout in milliseconds for the WebSocket upgrade handshake (default: `10_000`)
+- `:transport_opts` — options passed to the transport layer (`:gen_tcp` for `ws://`, `:ssl` for `wss://`)
+- `:protocols` — Mint HTTP protocols to use for the connection (default: `[:http1]`)
 
-The first argument is the initial user state accessible in callbacks.
+The first argument is the initial state passed to `init/1`.
 
 ### Callbacks
 
@@ -72,8 +75,11 @@ All callbacks are optional — default implementations are provided via `use Par
 
 | Callback | Description | Return values |
 |---|---|---|
+| `init(init_arg)` | Called when the process starts, before connecting | `{:ok, state}`, `{:stop, reason}` |
 | `handle_connect(state)` | Called when the WebSocket handshake completes | `{:ok, state}`, `{:push, frame, state}`, `{:stop, reason, state}` |
 | `handle_frame(frame, state)` | Called when a frame is received from the server | `{:ok, state}`, `{:push, frame, state}`, `{:stop, reason, state}` |
+| `handle_ping(payload, state)` | Called when a ping is received (pong sent automatically) | `{:ok, state}`, `{:push, frame, state}`, `{:stop, reason, state}` |
+| `handle_info(message, state)` | Called when a non-WebSocket message is received | `{:ok, state}`, `{:push, frame, state}`, `{:stop, reason, state}` |
 | `handle_disconnect(reason, state)` | Called when the connection is lost or closed | `{:ok, state}` |
 
 - `{:ok, state}` — update state

--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -192,7 +192,7 @@ defmodule Parley do
   @doc """
   Called when the process receives a message that is not a WebSocket frame.
 
-  This is the equivalent of `GenServer.handle_info/2`. Use it to handle
+  This is the equivalent of GenServer's `handle_info/2`. Use it to handle
   timer messages (`Process.send_after/3`), inter-process messages, and
   any other messages sent directly to the Parley process.
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Parley.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.2.0"
   @source_url "https://github.com/joaop21/parley"
 
   def project do


### PR DESCRIPTION
## Why

Parley has accumulated several new features since v0.1.1 — `init/1` callback, `handle_info/2` callback, `handle_ping/2` callback, connection options (`:headers`, `:transport_opts`, `:protocols`), and close-on-error-paths fixes. The version, README, and documentation need to reflect these additions before publishing to Hex.

## This change addresses the need by

- Bumping the version from `0.1.1` to `0.2.0` in `mix.exs`
- Updating the README dep version from `~> 0.1.0` to `~> 0.2.0`
- Adding all 6 callbacks to the README callbacks table (`init/1`, `handle_connect/1`, `handle_frame/2`, `handle_ping/2`, `handle_info/2`, `handle_disconnect/2`)
- Documenting new connection options (`:headers`, `:transport_opts`, `:protocols`) in the README options section
- Updating the `init_arg` description to reference `init/1`
- Fixing ExDoc warning for unresolvable `GenServer.handle_info/2` cross-reference in `lib/parley.ex`