### PR TITLE
Update connection lifecycle diagram to reflect current API

### DIFF
--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -79,25 +79,47 @@ defmodule Parley do
 
   ```mermaid
   stateDiagram-v2
-      [*] --> disconnected: start_link/3
+      [*] --> init: start_link/3
+      init --> disconnected: {:ok, state}
+      init --> [*]: {:stop, reason}
 
-      disconnected --> connecting: TCP connect + WebSocket upgrade
+      disconnected --> connecting: TCP connect + WS upgrade
+      disconnected --> [*]: connect / upgrade failure
 
       connecting --> connected: upgrade success
       connecting --> disconnected: error / timeout
 
       connected --> disconnected: error / close / disconnect/1
+      connected --> [*]: callback {:stop, ...}
+
+      state disconnected {
+          [*] --> handle_disconnect
+      }
 
       state connected {
           [*] --> handle_connect
           handle_connect --> waiting
           waiting --> handle_frame: frame received
           handle_frame --> waiting
+          waiting --> handle_ping: ping received
+          handle_ping --> waiting
       }
 
-      state disconnected {
-          [*] --> handle_disconnect
-      }
+      note right of connecting
+          send_frame/2 calls are queued
+          and replayed on connect
+      end note
+
+      note right of connected
+          Pings auto‑ponged before
+          handle_ping/2 is called
+      end note
+
+      note left of disconnected
+          handle_info/2 runs in all three
+          states. {:stop, ...} terminates
+          the process from any state.
+      end note
   ```
 
   - **`disconnected`** — initial state. On process start, immediately attempts to connect.


### PR DESCRIPTION
## Why

The Mermaid state diagram in the `Parley` `@moduledoc` was out of date. It did not reflect the `init/1`, `handle_info/2`, or `handle_ping/2` callbacks, nor did it show termination paths or the auto-pong / frame-queuing behaviour that the library now supports.

## This change addresses the need by

Replacing the old three-state diagram with an updated version that:

- Adds the **`init/1`** phase before the first `disconnected` state, showing `{:ok, state}` and `{:stop, reason}` return paths.
- Shows **termination exits** (`{:stop, ...}`) from both `connected` and `disconnected`, plus connect/upgrade failure.
- Includes **`handle_ping/2`** in the `connected` sub-state alongside `handle_frame/2`.
- Adds an annotation that **pings are auto-ponged** before `handle_ping/2` is called.
- Adds a note that **`send_frame/2` calls are queued** during the `connecting` phase and replayed on connect.
- Adds a note that **`handle_info/2` runs in all three states** and can return `{:stop, ...}` to terminate.

Closes #49, #50, #51, #52, #53, #54, #55.