### PR TITLE
Add automatic reconnection with configurable backoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Parley provides a callback-based API (`use Parley`) backed by a `gen_statem` sta
 @callback handle_frame(frame, state) :: {:ok, state} | {:push, frame, state} | {:stop, reason, state}
 @callback handle_ping(payload, state) :: {:ok, state} | {:push, frame, state} | {:stop, reason, state}
 @callback handle_info(message, state) :: {:ok, state} | {:push, frame, state} | {:stop, reason, state}
-@callback handle_disconnect(reason, state) :: {:ok, state}
+@callback handle_disconnect(reason, state) :: {:ok, state} | {:reconnect, state} | {:disconnect, state}
 ```
 
 ### Connection Options
@@ -46,12 +46,13 @@ Options passed to `Parley.start_link/3` or `Parley.start/3`:
 - `:connect_timeout` — timeout in ms for the WebSocket upgrade handshake (default: `10_000`)
 - `:transport_opts` — options passed to the transport layer (`:gen_tcp` / `:ssl`), for TLS config, timeouts, etc.
 - `:protocols` — Mint HTTP protocols (default: `[:http1]`)
+- `:reconnect` — automatic reconnection with exponential backoff. `false` (default), `true` (defaults: `base_delay: 1_000, max_delay: 30_000, max_retries: :infinity`), or a keyword list with custom values
 
 ### State Machine
 
-- **`:disconnected`** — Initial state. Triggers connection via internal event. Rejects sends with `{:error, :disconnected}`.
+- **`:disconnected`** — Initial state. Triggers connection via internal event. Rejects sends with `{:error, :disconnected}`. When reconnection is enabled, schedules retry with exponential backoff via `handle_disconnect/2` return value and `:reconnect` option.
 - **`:connecting`** — TCP connected, WebSocket upgrade in progress. Sends are postponed (auto-retried on connect).
-- **`:connected`** — Active. Frames flow through callbacks. Pings auto-responded with pong.
+- **`:connected`** — Active. Frames flow through callbacks. Pings auto-responded with pong. Resets reconnect attempt counter to 0 on entry.
 
 ### Dependencies
 

--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -64,6 +64,11 @@ defmodule Parley do
       (e.g. `[timeout: 5_000, cacertfile: "path/to/ca.pem"]`)
     * `:protocols` — Mint HTTP protocols to use for the connection
       (default: `[:http1]`)
+    * `:reconnect` — controls automatic reconnection with exponential backoff.
+      Accepts `false` (default, no reconnection), `true` (enable with defaults:
+      `base_delay: 1_000`, `max_delay: 30_000`, `max_retries: :infinity`), or a
+      keyword list with custom values for `:base_delay`, `:max_delay`, and
+      `:max_retries`
 
   ## Name registration
 
@@ -84,7 +89,7 @@ defmodule Parley do
       init --> [*]: {:stop, reason}
 
       disconnected --> connecting: TCP connect + WS upgrade
-      disconnected --> [*]: connect / upgrade failure
+      disconnected --> [*]: connect / upgrade failure (reconnect: false)
 
       connecting --> connected: upgrade success
       connecting --> disconnected: error / timeout
@@ -94,6 +99,8 @@ defmodule Parley do
 
       state disconnected {
           [*] --> handle_disconnect
+          handle_disconnect --> maybe_reconnect: {:ok, state} / {:reconnect, state}
+          handle_disconnect --> stay_disconnected: {:disconnect, state}
       }
 
       state connected {
@@ -111,7 +118,7 @@ defmodule Parley do
       end note
 
       note right of connected
-          Pings auto‑ponged before
+          Pings auto-ponged before
           handle_ping/2 is called
       end note
 
@@ -123,12 +130,14 @@ defmodule Parley do
   ```
 
   - **`disconnected`** — initial state. On process start, immediately attempts to connect.
-    Calls `c:handle_disconnect/2` when entering from another state.
+    Calls `c:handle_disconnect/2` when entering from another state. If reconnection is
+    enabled, schedules a reconnect attempt with exponential backoff.
   - **`connecting`** — TCP connection established, waiting for the WebSocket upgrade
     handshake to complete. Frames sent via `send_frame/2` during this state are
     automatically queued and delivered once connected.
   - **`connected`** — WebSocket upgrade complete. Calls `c:handle_connect/1` on entry,
-    then `c:handle_frame/2` for each frame received from the server.
+    then `c:handle_frame/2` for each frame received from the server. Resets the
+    reconnect attempt counter to 0.
 
   ## Callbacks
 
@@ -244,9 +253,15 @@ defmodule Parley do
 
   ## Return values
 
-    * `{:ok, state}` — acknowledge the disconnect
+    * `{:ok, state}` — defer to the configured `:reconnect` option. Reconnects
+      if the option is set, stays disconnected otherwise
+    * `{:reconnect, state}` — force reconnect regardless of the `:reconnect`
+      option. Uses default backoff values if no option was configured
+    * `{:disconnect, state}` — force stay disconnected, overriding the
+      `:reconnect` option
   """
-  @callback handle_disconnect(reason :: term(), state) :: {:ok, state}
+  @callback handle_disconnect(reason :: term(), state) ::
+              {:ok, state} | {:reconnect, state} | {:disconnect, state}
 
   defmacro __using__(_opts) do
     quote do
@@ -325,6 +340,9 @@ defmodule Parley do
       (e.g. `[timeout: 5_000, cacertfile: "path/to/ca.pem"]`)
     * `:protocols` — Mint HTTP protocols to use for the connection
       (default: `[:http1]`)
+    * `:reconnect` — controls automatic reconnection with exponential backoff.
+      Accepts `false` (default), `true` (enable with defaults), or a keyword
+      list with `:base_delay`, `:max_delay`, and `:max_retries`
 
   ## Return values
 
@@ -337,6 +355,7 @@ defmodule Parley do
     {headers, opts} = Keyword.pop(opts, :headers)
     {transport_opts, opts} = Keyword.pop(opts, :transport_opts)
     {protocols, opts} = Keyword.pop(opts, :protocols)
+    {reconnect, opts} = Keyword.pop(opts, :reconnect)
 
     connection_opts =
       Enum.reject(
@@ -344,7 +363,8 @@ defmodule Parley do
           connect_timeout: connect_timeout,
           headers: headers,
           transport_opts: transport_opts,
-          protocols: protocols
+          protocols: protocols,
+          reconnect: reconnect
         ],
         fn {_k, v} -> is_nil(v) end
       )
@@ -366,6 +386,7 @@ defmodule Parley do
     {headers, opts} = Keyword.pop(opts, :headers)
     {transport_opts, opts} = Keyword.pop(opts, :transport_opts)
     {protocols, opts} = Keyword.pop(opts, :protocols)
+    {reconnect, opts} = Keyword.pop(opts, :reconnect)
 
     connection_opts =
       Enum.reject(
@@ -373,7 +394,8 @@ defmodule Parley do
           connect_timeout: connect_timeout,
           headers: headers,
           transport_opts: transport_opts,
-          protocols: protocols
+          protocols: protocols,
+          reconnect: reconnect
         ],
         fn {_k, v} -> is_nil(v) end
       )
@@ -431,6 +453,7 @@ defmodule Parley do
 
   Sends a WebSocket close frame and transitions the process to the
   `:disconnected` state. The process remains alive after disconnecting.
+  If a reconnect timer is pending, it is cancelled.
 
   ## Examples
 

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -97,7 +97,12 @@ defmodule Parley.Connection do
         {:next_state, :connecting, %{data | conn: conn, request_ref: request_ref}}
 
       {:error, reason, data} ->
-        {:stop, {:error, reason}, data}
+        if data.reconnect == false do
+          {:stop, {:error, reason}, data}
+        else
+          {:keep_state, %{data | disconnect_reason: {:error, reason}},
+           [{:next_event, :internal, :connect_failed}]}
+        end
     end
   end
 

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -6,6 +6,7 @@ defmodule Parley.Connection do
   @behaviour :gen_statem
 
   @default_connect_timeout 10_000
+  @default_reconnect_opts [base_delay: 1_000, max_delay: 30_000, max_retries: :infinity]
 
   defstruct [
     :conn,
@@ -14,13 +15,16 @@ defmodule Parley.Connection do
     :uri,
     :module,
     :user_state,
+    :reconnect_timer,
     connect_timeout: @default_connect_timeout,
     headers: [],
     transport_opts: [],
     protocols: [:http1],
     status: nil,
     resp_headers: [],
-    disconnect_reason: :closed
+    disconnect_reason: :closed,
+    reconnect: false,
+    reconnect_attempt: 0
   ]
 
   ## gen_statem callbacks
@@ -37,6 +41,7 @@ defmodule Parley.Connection do
         headers = Keyword.get(opts, :headers, [])
         transport_opts = Keyword.get(opts, :transport_opts, [])
         protocols = Keyword.get(opts, :protocols, [:http1])
+        reconnect = parse_reconnect(Keyword.get(opts, :reconnect, false))
 
         data = %__MODULE__{
           uri: uri,
@@ -45,7 +50,8 @@ defmodule Parley.Connection do
           connect_timeout: connect_timeout,
           headers: headers,
           transport_opts: transport_opts,
-          protocols: protocols
+          protocols: protocols,
+          reconnect: reconnect
         }
 
         {:ok, :disconnected, data, [{:next_event, :internal, :connect}]}
@@ -64,44 +70,65 @@ defmodule Parley.Connection do
   def disconnected(:enter, _old_state, data) do
     if data.conn, do: Mint.HTTP.close(data.conn)
 
-    {:ok, user_state} = data.module.handle_disconnect(data.disconnect_reason, data.user_state)
+    data = %{
+      data
+      | conn: nil,
+        websocket: nil,
+        request_ref: nil,
+        status: nil,
+        resp_headers: []
+    }
 
-    {:keep_state,
-     %{
-       data
-       | user_state: user_state,
-         conn: nil,
-         websocket: nil,
-         request_ref: nil,
-         status: nil,
-         resp_headers: [],
-         disconnect_reason: :closed
-     }}
+    case data.module.handle_disconnect(data.disconnect_reason, data.user_state) do
+      {:reconnect, user_state} ->
+        maybe_reconnect(:reconnect, %{data | user_state: user_state, disconnect_reason: :closed})
+
+      {:disconnect, user_state} ->
+        {:keep_state, %{data | user_state: user_state, disconnect_reason: :closed}}
+
+      {:ok, user_state} ->
+        maybe_reconnect(:ok, %{data | user_state: user_state, disconnect_reason: :closed})
+    end
   end
 
   def disconnected(:internal, :connect, data) do
-    %{uri: uri} = data
+    case do_connect(data) do
+      {:ok, conn, request_ref} ->
+        {:next_state, :connecting, %{data | conn: conn, request_ref: request_ref}}
 
-    http_scheme = ws_to_http_scheme(uri.scheme)
-    port = uri.port || default_port(uri.scheme)
+      {:error, reason, data} ->
+        {:stop, {:error, reason}, data}
+    end
+  end
 
-    ws_scheme = ws_scheme(uri.scheme)
-    path = (uri.path || "/") <> if(uri.query, do: "?#{uri.query}", else: "")
+  def disconnected(:internal, :connect_failed, data) do
+    case data.module.handle_disconnect(data.disconnect_reason, data.user_state) do
+      {:reconnect, user_state} ->
+        maybe_reconnect(:reconnect, %{data | user_state: user_state, disconnect_reason: :closed})
 
-    connect_opts = [protocols: data.protocols, transport_opts: data.transport_opts]
+      {:disconnect, user_state} ->
+        {:keep_state, %{data | user_state: user_state, disconnect_reason: :closed}}
 
-    with {:ok, conn} <- Mint.HTTP.connect(http_scheme, uri.host, port, connect_opts),
-         {:ok, conn, request_ref} <- Mint.WebSocket.upgrade(ws_scheme, conn, path, data.headers) do
-      {:next_state, :connecting, %{data | conn: conn, request_ref: request_ref}}
+      {:ok, user_state} ->
+        maybe_reconnect(:ok, %{data | user_state: user_state, disconnect_reason: :closed})
+    end
+  end
+
+  def disconnected(:info, :reconnect, data) do
+    # Stale message -- timer was cancelled
+    if data.reconnect_timer == nil do
+      :keep_state_and_data
     else
-      # connect/3 fails
-      {:error, reason} ->
-        {:stop, {:error, reason}, data}
+      data = %{data | reconnect_timer: nil}
 
-      # upgrade/4 fails
-      {:error, conn, reason} ->
-        Mint.HTTP.close(conn)
-        {:stop, {:error, reason}, data}
+      case do_connect(data) do
+        {:ok, conn, request_ref} ->
+          {:next_state, :connecting, %{data | conn: conn, request_ref: request_ref}}
+
+        {:error, reason, data} ->
+          {:keep_state, %{data | disconnect_reason: {:error, reason}},
+           [{:next_event, :internal, :connect_failed}]}
+      end
     end
   end
 
@@ -123,8 +150,9 @@ defmodule Parley.Connection do
     {:keep_state_and_data, [{:reply, from, {:error, :disconnected}}]}
   end
 
-  def disconnected({:call, from}, :disconnect, _data) do
-    {:keep_state_and_data, [{:reply, from, :ok}]}
+  def disconnected({:call, from}, :disconnect, data) do
+    data = cancel_reconnect_timer(data)
+    {:keep_state, data, [{:reply, from, :ok}]}
   end
 
   ## :connecting state
@@ -172,6 +200,8 @@ defmodule Parley.Connection do
   ## :connected state
 
   def connected(:enter, :connecting, data) do
+    data = %{data | reconnect_attempt: 0, reconnect_timer: nil}
+
     case data.module.handle_connect(data.user_state) do
       {:ok, user_state} ->
         {:keep_state, %{data | user_state: user_state}}
@@ -251,6 +281,78 @@ defmodule Parley.Connection do
   end
 
   ## Private helpers
+
+  defp parse_reconnect(false), do: false
+  defp parse_reconnect(true), do: @default_reconnect_opts
+
+  defp parse_reconnect(opts) when is_list(opts) do
+    Keyword.merge(@default_reconnect_opts, opts)
+  end
+
+  defp do_connect(data) do
+    %{uri: uri} = data
+
+    http_scheme = ws_to_http_scheme(uri.scheme)
+    port = uri.port || default_port(uri.scheme)
+
+    ws_scheme = ws_scheme(uri.scheme)
+    path = (uri.path || "/") <> if(uri.query, do: "?#{uri.query}", else: "")
+
+    connect_opts = [protocols: data.protocols, transport_opts: data.transport_opts]
+
+    with {:ok, conn} <- Mint.HTTP.connect(http_scheme, uri.host, port, connect_opts),
+         {:ok, conn, request_ref} <- Mint.WebSocket.upgrade(ws_scheme, conn, path, data.headers) do
+      {:ok, conn, request_ref}
+    else
+      {:error, reason} ->
+        {:error, reason, data}
+
+      {:error, conn, reason} ->
+        Mint.HTTP.close(conn)
+        {:error, reason, data}
+    end
+  end
+
+  defp maybe_reconnect(callback_return, data) do
+    reconnect_opts = effective_reconnect_opts(callback_return, data.reconnect)
+
+    if reconnect_opts do
+      max_retries = Keyword.fetch!(reconnect_opts, :max_retries)
+
+      if max_retries != :infinity and data.reconnect_attempt >= max_retries do
+        {:stop, {:error, :max_retries_exceeded}, data}
+      else
+        base_delay = Keyword.fetch!(reconnect_opts, :base_delay)
+        max_delay = Keyword.fetch!(reconnect_opts, :max_delay)
+        delay = calculate_delay(base_delay, max_delay, data.reconnect_attempt)
+
+        timer = Process.send_after(self(), :reconnect, delay)
+
+        {:keep_state,
+         %{data | reconnect_timer: timer, reconnect_attempt: data.reconnect_attempt + 1}}
+      end
+    else
+      {:keep_state, data}
+    end
+  end
+
+  defp effective_reconnect_opts(:reconnect, false), do: @default_reconnect_opts
+  defp effective_reconnect_opts(:reconnect, opts) when is_list(opts), do: opts
+  defp effective_reconnect_opts(:ok, false), do: nil
+  defp effective_reconnect_opts(:ok, opts) when is_list(opts), do: opts
+
+  defp calculate_delay(base_delay, max_delay, attempt) do
+    delay = min(base_delay * Integer.pow(2, attempt), max_delay)
+    half = max(div(delay, 2), 1)
+    half + :rand.uniform(half)
+  end
+
+  defp cancel_reconnect_timer(%{reconnect_timer: nil} = data), do: data
+
+  defp cancel_reconnect_timer(%{reconnect_timer: timer} = data) do
+    Process.cancel_timer(timer)
+    %{data | reconnect_timer: nil}
+  end
 
   # Mint.HTTP.t() is opaque so Dialyzer can't prove Mint.WebSocket.new/4
   # can return {:ok, ...} through the opaque boundary.

--- a/test/parley/reconnection_test.exs
+++ b/test/parley/reconnection_test.exs
@@ -1,0 +1,537 @@
+defmodule Parley.ReconnectionTest do
+  use ExUnit.Case, async: true
+
+  alias Parley.Test.EchoServer
+
+  setup do
+    {port, server_pid} = EchoServer.start()
+
+    on_exit(fn ->
+      if Process.alive?(server_pid), do: Supervisor.stop(server_pid, :normal, 1000)
+    end)
+
+    %{port: port, url: "ws://localhost:#{port}/ws", server_pid: server_pid}
+  end
+
+  describe "reconnection on server crash" do
+    test "client reconnects after server dies", %{url: url, server_pid: server_pid} do
+      defmodule ReconnectOnCrashClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_frame(frame, %{test_pid: pid} = state) do
+          send(pid, {:frame, frame})
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(ReconnectOnCrashClient, %{test_pid: self()},
+          url: url,
+          reconnect: [base_delay: 50, max_delay: 200]
+        )
+
+      assert_receive :connected, 1000
+
+      # Kill the server
+      Supervisor.stop(server_pid, :normal, 1000)
+      assert_receive {:disconnected, _reason}, 1000
+
+      # Start a new server on the same port
+      {:ok, new_server_pid} =
+        Bandit.start_link(
+          plug: EchoServer.Router,
+          port: port_from_url(url),
+          ip: :loopback,
+          startup_log: false
+        )
+
+      Process.unlink(new_server_pid)
+
+      # Client should reconnect automatically
+      assert_receive :connected, 2000
+
+      # Verify we can exchange frames
+      :ok = Parley.send_frame(pid, {:text, "after reconnect"})
+      assert_receive {:frame, {:text, "after reconnect"}}, 1000
+
+      Parley.disconnect(pid)
+      Supervisor.stop(new_server_pid, :normal, 1000)
+    end
+  end
+
+  describe "backoff delay increases" do
+    test "successive attempts use increasing delays" do
+      defmodule BackoffDelayClient do
+        use Parley
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason, System.monotonic_time(:millisecond)})
+          {:ok, state}
+        end
+      end
+
+      Process.flag(:trap_exit, true)
+
+      # Connect to an unreachable host with reconnect enabled
+      {:ok, pid} =
+        Parley.start_link(BackoffDelayClient, %{test_pid: self()},
+          url: "ws://127.0.0.1:1/ws",
+          reconnect: [base_delay: 50, max_delay: 400, max_retries: 4]
+        )
+
+      # Collect timestamps of disconnect callbacks (triggered by connect_failed)
+      timestamps =
+        for _i <- 1..4 do
+          assert_receive {:disconnected, _reason, ts}, 5000
+          ts
+        end
+
+      # Verify delays increase (with some tolerance for jitter)
+      delays =
+        timestamps
+        |> Enum.chunk_every(2, 1, :discard)
+        |> Enum.map(fn [a, b] -> b - a end)
+
+      # Each delay should generally be >= the previous one
+      assert length(delays) >= 2
+      assert Enum.at(delays, -1) >= Enum.at(delays, 0)
+
+      assert_receive {:EXIT, ^pid, {:error, :max_retries_exceeded}}, 5000
+    end
+  end
+
+  describe "max retries exceeded" do
+    test "process stops with :max_retries_exceeded" do
+      defmodule MaxRetriesClient do
+        use Parley
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      Process.flag(:trap_exit, true)
+
+      {:ok, pid} =
+        Parley.start_link(MaxRetriesClient, %{test_pid: self()},
+          url: "ws://127.0.0.1:1/ws",
+          reconnect: [base_delay: 50, max_delay: 100, max_retries: 3]
+        )
+
+      # Should get 3 disconnect notifications then stop
+      for _i <- 1..3 do
+        assert_receive {:disconnected, _reason}, 2000
+      end
+
+      assert_receive {:EXIT, ^pid, {:error, :max_retries_exceeded}}, 2000
+    end
+  end
+
+  describe "{:disconnect, state} suppresses reconnection" do
+    test "overrides reconnect option", %{url: url, server_pid: server_pid} do
+      defmodule DisconnectOverrideClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:disconnect, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(DisconnectOverrideClient, %{test_pid: self()},
+          url: url,
+          reconnect: [base_delay: 50, max_delay: 200]
+        )
+
+      assert_receive :connected, 1000
+
+      # Kill the server
+      Supervisor.stop(server_pid, :normal, 1000)
+      assert_receive {:disconnected, _reason}, 1000
+
+      # Should NOT reconnect
+      refute_receive :connected, 500
+
+      # Process should still be alive
+      assert Process.alive?(pid)
+      Parley.disconnect(pid)
+    end
+  end
+
+  describe "{:reconnect, state} forces reconnection" do
+    test "reconnects even without reconnect option", %{url: url, server_pid: server_pid} do
+      defmodule ForceReconnectClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_frame(frame, %{test_pid: pid} = state) do
+          send(pid, {:frame, frame})
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:reconnect, state}
+        end
+      end
+
+      # No reconnect option set
+      {:ok, pid} =
+        Parley.start_link(ForceReconnectClient, %{test_pid: self()}, url: url)
+
+      assert_receive :connected, 1000
+
+      # Kill the server
+      Supervisor.stop(server_pid, :normal, 1000)
+      assert_receive {:disconnected, _reason}, 1000
+
+      # Start a new server on the same port
+      {:ok, new_server_pid} =
+        Bandit.start_link(
+          plug: EchoServer.Router,
+          port: port_from_url(url),
+          ip: :loopback,
+          startup_log: false
+        )
+
+      Process.unlink(new_server_pid)
+
+      # Should reconnect using default backoff
+      assert_receive :connected, 5000
+
+      :ok = Parley.send_frame(pid, {:text, "reconnected"})
+      assert_receive {:frame, {:text, "reconnected"}}, 1000
+
+      Parley.disconnect(pid)
+      Supervisor.stop(new_server_pid, :normal, 1000)
+    end
+  end
+
+  describe "{:ok, state} defers to option" do
+    test "with reconnect option, default callback triggers reconnection", %{
+      url: url,
+      server_pid: server_pid
+    } do
+      defmodule DeferToOptionClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(DeferToOptionClient, %{test_pid: self()},
+          url: url,
+          reconnect: [base_delay: 50, max_delay: 200]
+        )
+
+      assert_receive :connected, 1000
+
+      Supervisor.stop(server_pid, :normal, 1000)
+      assert_receive {:disconnected, _reason}, 1000
+
+      # Start a new server on the same port
+      {:ok, new_server_pid} =
+        Bandit.start_link(
+          plug: EchoServer.Router,
+          port: port_from_url(url),
+          ip: :loopback,
+          startup_log: false
+        )
+
+      Process.unlink(new_server_pid)
+
+      # {:ok, state} + reconnect option -> reconnects
+      assert_receive :connected, 2000
+
+      Parley.disconnect(pid)
+      Supervisor.stop(new_server_pid, :normal, 1000)
+    end
+
+    test "without reconnect option, default callback stays disconnected", %{
+      url: url,
+      server_pid: server_pid
+    } do
+      defmodule NoReconnectOptionClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      # No reconnect option
+      {:ok, pid} =
+        Parley.start_link(NoReconnectOptionClient, %{test_pid: self()}, url: url)
+
+      assert_receive :connected, 1000
+
+      Supervisor.stop(server_pid, :normal, 1000)
+      assert_receive {:disconnected, _reason}, 1000
+
+      # Should NOT reconnect
+      refute_receive :connected, 500
+
+      assert Process.alive?(pid)
+      Parley.disconnect(pid)
+    end
+  end
+
+  describe "disconnect/1 cancels pending reconnect" do
+    test "calling disconnect cancels the reconnect timer", %{url: url, server_pid: server_pid} do
+      defmodule CancelTimerClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(CancelTimerClient, %{test_pid: self()},
+          url: url,
+          reconnect: [base_delay: 2000, max_delay: 5000]
+        )
+
+      assert_receive :connected, 1000
+
+      # Kill the server — triggers reconnect timer with long delay
+      Supervisor.stop(server_pid, :normal, 1000)
+      assert_receive {:disconnected, _reason}, 1000
+
+      # Immediately cancel via disconnect
+      :ok = Parley.disconnect(pid)
+
+      # Should NOT attempt reconnect
+      refute_receive :connected, 500
+
+      assert Process.alive?(pid)
+    end
+  end
+
+  describe "initial connection failure retries" do
+    test "retries with reconnect option then succeeds" do
+      defmodule InitialRetryClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_frame(frame, %{test_pid: pid} = state) do
+          send(pid, {:frame, frame})
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      # Find a free port and don't start a server on it yet
+      {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
+      {:ok, free_port} = :inet.port(listen)
+      :gen_tcp.close(listen)
+
+      {:ok, _pid} =
+        Parley.start_link(InitialRetryClient, %{test_pid: self()},
+          url: "ws://127.0.0.1:#{free_port}/ws",
+          reconnect: [base_delay: 50, max_delay: 200]
+        )
+
+      # The initial connection fails
+      assert_receive {:disconnected, _reason}, 1000
+
+      # Start a server on that port so the retry succeeds
+      {:ok, new_server_pid} =
+        Bandit.start_link(
+          plug: EchoServer.Router,
+          port: free_port,
+          ip: {127, 0, 0, 1},
+          startup_log: false
+        )
+
+      Process.unlink(new_server_pid)
+
+      # Should eventually reconnect
+      assert_receive :connected, 5000
+
+      Parley.disconnect(self() |> Process.info(:links) |> elem(1) |> List.last())
+      Supervisor.stop(new_server_pid, :normal, 1000)
+    end
+  end
+
+  describe "attempt counter resets on success" do
+    test "backoff starts fresh after successful reconnect", %{url: url, server_pid: server_pid} do
+      defmodule AttemptResetClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason, System.monotonic_time(:millisecond)})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(AttemptResetClient, %{test_pid: self()},
+          url: url,
+          reconnect: [base_delay: 50, max_delay: 200]
+        )
+
+      assert_receive :connected, 1000
+
+      # First disconnect cycle
+      Supervisor.stop(server_pid, :normal, 1000)
+      assert_receive {:disconnected, _reason, _ts}, 1000
+
+      # Start new server for reconnect
+      {:ok, server_pid2} =
+        Bandit.start_link(
+          plug: EchoServer.Router,
+          port: port_from_url(url),
+          ip: :loopback,
+          startup_log: false
+        )
+
+      Process.unlink(server_pid2)
+      assert_receive :connected, 2000
+
+      # Second disconnect cycle
+      Supervisor.stop(server_pid2, :normal, 1000)
+      assert_receive {:disconnected, _reason2, ts2}, 1000
+
+      # Start another server
+      {:ok, server_pid3} =
+        Bandit.start_link(
+          plug: EchoServer.Router,
+          port: port_from_url(url),
+          ip: :loopback,
+          startup_log: false
+        )
+
+      Process.unlink(server_pid3)
+      assert_receive :connected, 2000
+
+      # The reconnect delay after the second disconnect should be short
+      # (base_delay level, not accumulated), proving the counter was reset
+      now = System.monotonic_time(:millisecond)
+      # Should have reconnected within a reasonable time from ts2
+      assert now - ts2 < 1000
+
+      Parley.disconnect(pid)
+      Supervisor.stop(server_pid3, :normal, 1000)
+    end
+  end
+
+  describe "{:reconnect, state} without option uses defaults" do
+    test "uses default backoff values", %{url: url, server_pid: server_pid} do
+      defmodule ReconnectNoOptionClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:reconnect, state}
+        end
+      end
+
+      # No reconnect option, but callback forces reconnect
+      {:ok, pid} =
+        Parley.start_link(ReconnectNoOptionClient, %{test_pid: self()}, url: url)
+
+      assert_receive :connected, 1000
+
+      # Kill the server — handle_disconnect returns {:reconnect, state}
+      Supervisor.stop(server_pid, :normal, 1000)
+      assert_receive {:disconnected, _reason}, 1000
+
+      # Should get another disconnect (from the failed reconnect attempt using
+      # default backoff), proving reconnection was attempted
+      assert_receive {:disconnected, _reason}, 3000
+
+      # Process should still be alive (infinite retries with defaults)
+      assert Process.alive?(pid)
+
+      # Clean up
+      Parley.disconnect(pid)
+    end
+  end
+
+  defp port_from_url(url) do
+    URI.parse(url).port
+  end
+end


### PR DESCRIPTION
## Why

When a WebSocket connection drops (server crash, network blip, timeout), users currently have to implement their own reconnection logic outside of Parley. This is error-prone and requires duplicating backoff/retry patterns across every client. Issues #6 and #7 request built-in reconnection with configurable exponential backoff, and the ability for `handle_disconnect/2` to control reconnection behavior per-disconnect.

## This change addresses the need by

- Adding a `:reconnect` option to `start_link/3` and `start/3` that accepts `false` (default, current behavior), `true` (enable with defaults: `base_delay: 1_000`, `max_delay: 30_000`, `max_retries: :infinity`), or a keyword list with custom backoff configuration.

- Extending the `handle_disconnect/2` callback to return `{:ok, state}` (defer to configured option), `{:reconnect, state}` (force reconnect, using default backoff if no option configured), or `{:disconnect, state}` (force stay disconnected, overriding option).

- Implementing exponential backoff with jitter: `delay = min(base_delay * 2^attempt, max_delay)`, jittered to 50-100% of the calculated delay. The attempt counter resets to 0 on successful connection.

- Adding `maybe_reconnect` logic that checks max retries (stopping with `{:error, :max_retries_exceeded}` when exhausted), schedules retry via `Process.send_after/3`, and handles stale timer messages.

- Using `{:next_event, :internal, :connect_failed}` for failed connection attempts (since `disconnected -> disconnected` self-transitions do not fire enter callbacks in gen_statem), ensuring `handle_disconnect/2` is always called on failure.

- Cancelling pending reconnect timers when `disconnect/1` is called.

- Adding 11 tests covering: reconnection on server crash, backoff delay increases, max retries exceeded, `{:disconnect, state}` suppresses reconnection, `{:reconnect, state}` forces reconnection, `{:ok, state}` defers to option, `disconnect/1` cancels pending reconnect, initial connection failure retries, attempt counter resets on success, and `{:reconnect, state}` without option uses defaults.

- Updating AGENTS.md with the new callback signatures, connection options, and state machine description.