### PR TITLE
Add {:disconnect, reason, state} callback return type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,10 @@ Parley provides a callback-based API (`use Parley`) backed by a `gen_statem` sta
 
 ```elixir
 @callback init(init_arg) :: {:ok, state} | {:stop, reason}
-@callback handle_connect(state) :: {:ok, state} | {:push, frame, state} | {:stop, reason, state}
-@callback handle_frame(frame, state) :: {:ok, state} | {:push, frame, state} | {:stop, reason, state}
-@callback handle_ping(payload, state) :: {:ok, state} | {:push, frame, state} | {:stop, reason, state}
-@callback handle_info(message, state) :: {:ok, state} | {:push, frame, state} | {:stop, reason, state}
+@callback handle_connect(state) :: {:ok, state} | {:push, frame, state} | {:disconnect, reason, state} | {:stop, reason, state}
+@callback handle_frame(frame, state) :: {:ok, state} | {:push, frame, state} | {:disconnect, reason, state} | {:stop, reason, state}
+@callback handle_ping(payload, state) :: {:ok, state} | {:push, frame, state} | {:disconnect, reason, state} | {:stop, reason, state}
+@callback handle_info(message, state) :: {:ok, state} | {:push, frame, state} | {:disconnect, reason, state} | {:stop, reason, state}
 @callback handle_disconnect(reason, state) :: {:ok, state} | {:reconnect, state} | {:disconnect, state}
 ```
 

--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -153,7 +153,8 @@ defmodule Parley do
     * `c:handle_disconnect/2` — called when the connection is lost or closed
 
   `c:handle_connect/1`, `c:handle_frame/2`, `c:handle_ping/2`, and `c:handle_info/2` also support
-  `{:push, frame, state}` to send a frame from within the callback, and
+  `{:push, frame, state}` to send a frame from within the callback,
+  `{:disconnect, reason, state}` to gracefully close the connection while keeping the process alive, and
   `{:stop, reason, state}` to stop the process. See the callback docs for details.
   """
 
@@ -185,10 +186,15 @@ defmodule Parley do
     * `{:ok, state}` — update state, remain connected
     * `{:push, frame, state}` — send a frame immediately after connecting
       (useful for auth or subscribe messages)
+    * `{:disconnect, reason, state}` — close the connection gracefully but
+      keep the process alive. The reason is passed to `c:handle_disconnect/2`
     * `{:stop, reason, state}` — reject the connection, stop the process
   """
   @callback handle_connect(state) ::
-              {:ok, state} | {:push, frame, state} | {:stop, reason :: term(), state}
+              {:ok, state}
+              | {:push, frame, state}
+              | {:disconnect, reason :: term(), state}
+              | {:stop, reason :: term(), state}
 
   @doc """
   Called when a frame is received from the server.
@@ -197,10 +203,15 @@ defmodule Parley do
 
     * `{:ok, state}` — update state
     * `{:push, frame, state}` — send a frame back to the server
+    * `{:disconnect, reason, state}` — close the connection gracefully but
+      keep the process alive. The reason is passed to `c:handle_disconnect/2`
     * `{:stop, reason, state}` — close the connection and stop the process
   """
   @callback handle_frame(frame, state) ::
-              {:ok, state} | {:push, frame, state} | {:stop, reason :: term(), state}
+              {:ok, state}
+              | {:push, frame, state}
+              | {:disconnect, reason :: term(), state}
+              | {:stop, reason :: term(), state}
 
   @doc """
   Called when a ping frame is received.
@@ -213,11 +224,14 @@ defmodule Parley do
 
     * `{:ok, state}` — continue with updated state
     * `{:push, frame, state}` — send a frame and continue
+    * `{:disconnect, reason, state}` — close the connection gracefully but
+      keep the process alive. The reason is passed to `c:handle_disconnect/2`
     * `{:stop, reason, state}` — gracefully stop the connection
   """
   @callback handle_ping(payload :: binary(), state) ::
               {:ok, state}
               | {:push, frame, state}
+              | {:disconnect, reason :: term(), state}
               | {:stop, reason :: term(), state}
 
   @doc """
@@ -236,10 +250,16 @@ defmodule Parley do
 
     * `{:ok, state}` — update state
     * `{:push, frame, state}` — send a frame to the server (connected only)
+    * `{:disconnect, reason, state}` — close the connection gracefully but
+      keep the process alive. The reason is passed to `c:handle_disconnect/2`.
+      While already disconnected, the state is updated but no transition occurs
     * `{:stop, reason, state}` — stop the process
   """
   @callback handle_info(message :: term(), state) ::
-              {:ok, state} | {:push, frame, state} | {:stop, reason :: term(), state}
+              {:ok, state}
+              | {:push, frame, state}
+              | {:disconnect, reason :: term(), state}
+              | {:stop, reason :: term(), state}
 
   @doc """
   Called when the connection is lost or closed.
@@ -250,6 +270,7 @@ defmodule Parley do
     * `{:remote_close, code, reason}` — server-initiated close frame
     * `{:error, reason}` — stream or decode error
     * `:connect_timeout` — WebSocket upgrade handshake timed out
+    * any user-provided term — from a `{:disconnect, reason, state}` callback return
 
   ## Return values
 

--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -220,7 +220,7 @@ defmodule Parley do
   invoked, so the WebSocket protocol is never violated. Use this callback
   to observe pings for heartbeat monitoring, latency tracking, or logging.
 
-  Supported return values:
+  ## Return values
 
     * `{:ok, state}` — continue with updated state
     * `{:push, frame, state}` — send a frame and continue

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -237,7 +237,7 @@ defmodule Parley.Connection do
       {:disconnect, reason, user_state} ->
         data = %{data | user_state: user_state, disconnect_reason: reason}
         data = send_close(data)
-        {:keep_state, data, [{:next_event, :internal, :user_disconnect}]}
+        {:keep_state, data, [{:state_timeout, 0, :user_disconnect}]}
 
       {:stop, reason, user_state} ->
         if data.conn, do: Mint.HTTP.close(data.conn)
@@ -245,7 +245,7 @@ defmodule Parley.Connection do
     end
   end
 
-  def connected(:internal, :user_disconnect, data) do
+  def connected(:state_timeout, :user_disconnect, data) do
     {:next_state, :disconnected, data}
   end
 

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -190,9 +190,9 @@ defmodule Parley.Connection do
             Logger.warning("Ignoring {:push, ...} from handle_info/2 while connecting")
             {:keep_state, %{data | user_state: user_state}}
 
-          {:disconnect, _reason, user_state} ->
-            Logger.warning("Ignoring {:disconnect, ...} from handle_info/2 while connecting")
-            {:keep_state, %{data | user_state: user_state}}
+          {:disconnect, reason, user_state} ->
+            {:next_state, :disconnected,
+             %{data | user_state: user_state, disconnect_reason: reason}}
 
           {:stop, reason, user_state} ->
             if data.conn, do: Mint.HTTP.close(data.conn)
@@ -234,6 +234,9 @@ defmodule Parley.Connection do
              [{:next_event, :internal, :send_failed}]}
         end
 
+      # Enter callbacks cannot perform state transitions or emit internal
+      # events, so we schedule an immediate state timeout to transition
+      # to :disconnected on the next step.
       {:disconnect, reason, user_state} ->
         data = %{data | user_state: user_state, disconnect_reason: reason}
         data = send_close(data)

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -146,6 +146,9 @@ defmodule Parley.Connection do
         Logger.warning("Ignoring {:push, ...} from handle_info/2 while disconnected")
         {:keep_state, %{data | user_state: user_state}}
 
+      {:disconnect, _reason, user_state} ->
+        {:keep_state, %{data | user_state: user_state}}
+
       {:stop, reason, user_state} ->
         {:stop, reason, %{data | user_state: user_state}}
     end
@@ -185,6 +188,10 @@ defmodule Parley.Connection do
 
           {:push, _frame, user_state} ->
             Logger.warning("Ignoring {:push, ...} from handle_info/2 while connecting")
+            {:keep_state, %{data | user_state: user_state}}
+
+          {:disconnect, _reason, user_state} ->
+            Logger.warning("Ignoring {:disconnect, ...} from handle_info/2 while connecting")
             {:keep_state, %{data | user_state: user_state}}
 
           {:stop, reason, user_state} ->
@@ -227,10 +234,19 @@ defmodule Parley.Connection do
              [{:next_event, :internal, :send_failed}]}
         end
 
+      {:disconnect, reason, user_state} ->
+        data = %{data | user_state: user_state, disconnect_reason: reason}
+        data = send_close(data)
+        {:keep_state, data, [{:next_event, :internal, :user_disconnect}]}
+
       {:stop, reason, user_state} ->
         if data.conn, do: Mint.HTTP.close(data.conn)
         {:stop, reason, %{data | user_state: user_state, conn: nil}}
     end
+  end
+
+  def connected(:internal, :user_disconnect, data) do
+    {:next_state, :disconnected, data}
   end
 
   def connected(:internal, :send_failed, data) do
@@ -423,6 +439,9 @@ defmodule Parley.Connection do
           {:close_on_send_error, reason, data} ->
             {:next_state, :disconnected, %{data | disconnect_reason: {:error, reason}}}
 
+          {:disconnect, reason, data} ->
+            {:next_state, :disconnected, %{data | disconnect_reason: reason}}
+
           {:stop, reason, data} ->
             if data.conn, do: Mint.HTTP.close(data.conn)
             {:stop, reason, %{data | conn: nil}}
@@ -469,6 +488,11 @@ defmodule Parley.Connection do
     end
   end
 
+  defp handle_frame_result({:disconnect, reason, user_state}, data) do
+    data = send_close(data)
+    {:halt, {:disconnect, reason, %{data | user_state: user_state}}}
+  end
+
   defp handle_frame_result({:stop, reason, user_state}, data) do
     {:halt, {:stop, reason, %{data | user_state: user_state}}}
   end
@@ -492,6 +516,12 @@ defmodule Parley.Connection do
         {:keep_state, %{data | disconnect_reason: {:error, reason}},
          [{:next_event, :internal, :send_failed}]}
     end
+  end
+
+  defp handle_info_result({:disconnect, reason, user_state}, data) do
+    data = %{data | user_state: user_state}
+    data = send_close(data)
+    {:next_state, :disconnected, %{data | disconnect_reason: reason}}
   end
 
   defp handle_info_result({:stop, reason, user_state}, data) do

--- a/test/parley/disconnect_return_test.exs
+++ b/test/parley/disconnect_return_test.exs
@@ -1,0 +1,318 @@
+defmodule Parley.DisconnectReturnTest do
+  use ExUnit.Case, async: true
+
+  alias Parley.Test.EchoServer
+
+  setup do
+    {port, server_pid} = EchoServer.start()
+
+    on_exit(fn ->
+      if Process.alive?(server_pid), do: Supervisor.stop(server_pid, :normal, 1000)
+    end)
+
+    %{port: port, url: "ws://localhost:#{port}/ws", server_pid: server_pid}
+  end
+
+  describe "handle_connect returning {:disconnect, reason, state}" do
+    test "disconnects gracefully and handle_disconnect receives the reason", %{url: url} do
+      defmodule DisconnectOnConnectClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:disconnect, :not_authorized, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(DisconnectOnConnectClient, %{test_pid: self()}, url: url)
+
+      assert_receive :connected, 1000
+      assert_receive {:disconnected, :not_authorized}, 1000
+
+      assert Process.alive?(pid)
+      Parley.disconnect(pid)
+    end
+  end
+
+  describe "handle_frame returning {:disconnect, reason, state}" do
+    test "disconnects gracefully and handle_disconnect receives the reason", %{url: url} do
+      defmodule DisconnectOnFrameClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_frame({:text, "bye"}, state) do
+          {:disconnect, :server_said_bye, state}
+        end
+
+        def handle_frame(_frame, state), do: {:ok, state}
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(DisconnectOnFrameClient, %{test_pid: self()}, url: url)
+
+      assert_receive :connected, 1000
+
+      :ok = Parley.send_frame(pid, {:text, "bye"})
+      assert_receive {:disconnected, :server_said_bye}, 1000
+
+      assert Process.alive?(pid)
+      Parley.disconnect(pid)
+    end
+  end
+
+  describe "handle_ping returning {:disconnect, reason, state}" do
+    test "disconnects gracefully and handle_disconnect receives the reason", %{url: url} do
+      defmodule DisconnectOnPingClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_ping(_payload, state) do
+          {:disconnect, :ping_triggered_disconnect, state}
+        end
+
+        @impl true
+        def handle_frame(_frame, state), do: {:ok, state}
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(DisconnectOnPingClient, %{test_pid: self()}, url: url)
+
+      assert_receive :connected, 1000
+
+      # Trigger a server-sent ping
+      :ok = Parley.send_frame(pid, {:text, "send_ping"})
+      assert_receive {:disconnected, :ping_triggered_disconnect}, 1000
+
+      assert Process.alive?(pid)
+      Parley.disconnect(pid)
+    end
+  end
+
+  describe "handle_info returning {:disconnect, reason, state}" do
+    test "disconnects gracefully while connected", %{url: url} do
+      defmodule DisconnectOnInfoClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_info(:please_disconnect, state) do
+          {:disconnect, :info_disconnect, state}
+        end
+
+        def handle_info(_message, state), do: {:ok, state}
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(DisconnectOnInfoClient, %{test_pid: self()}, url: url)
+
+      assert_receive :connected, 1000
+
+      send(pid, :please_disconnect)
+      assert_receive {:disconnected, :info_disconnect}, 1000
+
+      assert Process.alive?(pid)
+      Parley.disconnect(pid)
+    end
+
+    test "stays disconnected when already disconnected, updates state", %{url: url} do
+      defmodule DisconnectOnInfoWhileDisconnectedClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_info(:try_disconnect, state) do
+          {:disconnect, :already_off, %{state | got_disconnect_info: true}}
+        end
+
+        def handle_info(:check_state, %{test_pid: pid} = state) do
+          send(pid, {:state, state})
+          {:ok, state}
+        end
+
+        def handle_info(_message, state), do: {:ok, state}
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(
+          DisconnectOnInfoWhileDisconnectedClient,
+          %{test_pid: self(), got_disconnect_info: false},
+          url: url
+        )
+
+      assert_receive :connected, 1000
+
+      # First disconnect normally
+      :ok = Parley.disconnect(pid)
+      assert_receive {:disconnected, :closed}, 1000
+
+      # Now send {:disconnect, ...} while already disconnected
+      send(pid, :try_disconnect)
+
+      # Should NOT get another handle_disconnect call
+      refute_receive {:disconnected, _}, 200
+
+      # Verify state was updated
+      send(pid, :check_state)
+      assert_receive {:state, %{got_disconnect_info: true}}, 1000
+
+      assert Process.alive?(pid)
+      Parley.disconnect(pid)
+    end
+  end
+
+  describe "disconnect return with reconnection" do
+    test "handle_frame disconnect triggers reconnection via handle_disconnect", %{
+      url: url,
+      server_pid: server_pid
+    } do
+      defmodule DisconnectThenReconnectClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_frame({:text, "disconnect_me"}, state) do
+          {:disconnect, :unauthorized, state}
+        end
+
+        def handle_frame(frame, %{test_pid: pid} = state) do
+          send(pid, {:frame, frame})
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:reconnect, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(DisconnectThenReconnectClient, %{test_pid: self()}, url: url)
+
+      assert_receive :connected, 1000
+
+      # Trigger the disconnect from handle_frame
+      :ok = Parley.send_frame(pid, {:text, "disconnect_me"})
+      assert_receive {:disconnected, :unauthorized}, 1000
+
+      # Should reconnect since handle_disconnect returns {:reconnect, state}
+      assert_receive :connected, 5000
+
+      # Verify we can exchange frames after reconnecting
+      :ok = Parley.send_frame(pid, {:text, "after reconnect"})
+      assert_receive {:frame, {:text, "after reconnect"}}, 1000
+
+      assert Process.alive?(pid)
+      Parley.disconnect(pid)
+    end
+  end
+
+  describe "state is preserved through disconnect" do
+    test "handle_frame disconnect preserves updated state", %{url: url} do
+      defmodule StatePreservingDisconnectClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_frame({:text, "disconnect_me"}, state) do
+          {:disconnect, :done, %{state | disconnected_by_frame: true}}
+        end
+
+        def handle_frame(_frame, state), do: {:ok, state}
+
+        @impl true
+        def handle_info(:check_state, %{test_pid: pid} = state) do
+          send(pid, {:state, state})
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason, state})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(
+          StatePreservingDisconnectClient,
+          %{test_pid: self(), disconnected_by_frame: false},
+          url: url
+        )
+
+      assert_receive :connected, 1000
+
+      :ok = Parley.send_frame(pid, {:text, "disconnect_me"})
+
+      # handle_disconnect should see the updated state
+      assert_receive {:disconnected, :done, %{disconnected_by_frame: true}}, 1000
+
+      assert Process.alive?(pid)
+      Parley.disconnect(pid)
+    end
+  end
+end


### PR DESCRIPTION
Closes #33

## Why

Currently, callbacks (`handle_connect/1`, `handle_frame/2`, `handle_ping/2`, `handle_info/2`) only support `{:ok, state}`, `{:push, frame, state}`, and `{:stop, reason, state}` as return values. There is no way to gracefully close the WebSocket connection from a callback while keeping the process alive. This is needed for scenarios like auth failures, orderly shutdowns, and session completion where the process should survive for potential reconnection.

## This change addresses the need by

- Adding `{:disconnect, reason, state}` as a return type to the four affected callbacks in the behaviour module (`lib/parley.ex`), with updated typespecs and docs
- Handling the new return in the connection state machine (`lib/parley/connection.ex`): sends a WebSocket close frame (best effort), sets the user-provided reason as `disconnect_reason`, and transitions to `:disconnected` where `handle_disconnect/2` receives that reason
- Using `{:state_timeout, 0, :user_disconnect}` for the `handle_connect` path since gen_statem enter callbacks do not allow `{:next_event, ...}` actions
- Handling the edge case where `handle_info/2` returns `{:disconnect, ...}` while already disconnected (silently updates state, no transition)
- Adding comprehensive tests for all four callbacks, the disconnected edge case, state preservation, and reconnection integration
- Updating `AGENTS.md` callback return type summary