### PR TITLE
Release v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Parley.disconnect(pid)
 - `:connect_timeout` — timeout in milliseconds for the WebSocket upgrade handshake (default: `10_000`)
 - `:transport_opts` — options passed to the transport layer (`:gen_tcp` for `ws://`, `:ssl` for `wss://`)
 - `:protocols` — Mint HTTP protocols to use for the connection (default: `[:http1]`)
+- `:reconnect` — controls automatic reconnection with exponential backoff. Accepts `false` (default, no reconnection), `true` (enable with defaults: `base_delay: 1_000`, `max_delay: 30_000`, `max_retries: :infinity`), or a keyword list with custom values for `:base_delay`, `:max_delay`, and `:max_retries`
 
 The first argument is the initial state passed to `init/1`.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add `parley` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:parley, "~> 0.2.0"}
+    {:parley, "~> 0.3.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -77,15 +77,18 @@ All callbacks are optional — default implementations are provided via `use Par
 | Callback | Description | Return values |
 |---|---|---|
 | `init(init_arg)` | Called when the process starts, before connecting | `{:ok, state}`, `{:stop, reason}` |
-| `handle_connect(state)` | Called when the WebSocket handshake completes | `{:ok, state}`, `{:push, frame, state}`, `{:stop, reason, state}` |
-| `handle_frame(frame, state)` | Called when a frame is received from the server | `{:ok, state}`, `{:push, frame, state}`, `{:stop, reason, state}` |
-| `handle_ping(payload, state)` | Called when a ping is received (pong sent automatically) | `{:ok, state}`, `{:push, frame, state}`, `{:stop, reason, state}` |
-| `handle_info(message, state)` | Called when a non-WebSocket message is received | `{:ok, state}`, `{:push, frame, state}`, `{:stop, reason, state}` |
-| `handle_disconnect(reason, state)` | Called when the connection is lost or closed | `{:ok, state}` |
+| `handle_connect(state)` | Called when the WebSocket handshake completes | `{:ok, state}`, `{:push, frame, state}`, `{:disconnect, reason, state}`, `{:stop, reason, state}` |
+| `handle_frame(frame, state)` | Called when a frame is received from the server | `{:ok, state}`, `{:push, frame, state}`, `{:disconnect, reason, state}`, `{:stop, reason, state}` |
+| `handle_ping(payload, state)` | Called when a ping is received (pong sent automatically) | `{:ok, state}`, `{:push, frame, state}`, `{:disconnect, reason, state}`, `{:stop, reason, state}` |
+| `handle_info(message, state)` | Called when a non-WebSocket message is received | `{:ok, state}`, `{:push, frame, state}`, `{:disconnect, reason, state}`, `{:stop, reason, state}` |
+| `handle_disconnect(reason, state)` | Called when the connection is lost or closed | `{:ok, state}`, `{:reconnect, state}`, `{:disconnect, state}` |
 
 - `{:ok, state}` — update state
 - `{:push, frame, state}` — send a frame from within the callback
+- `{:disconnect, reason, state}` — close the connection gracefully but keep the process alive
 - `{:stop, reason, state}` — stop the process
+- `{:reconnect, state}` — force reconnect (`handle_disconnect` only)
+- `{:disconnect, state}` — force stay disconnected (`handle_disconnect` only)
 
 ### Frame Types
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Parley.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
   @source_url "https://github.com/joaop21/parley"
 
   def project do


### PR DESCRIPTION
## Why

Parley has accumulated several significant features since v0.2.0 that are ready for release: automatic reconnection with configurable backoff, a new `{:disconnect, reason, state}` callback return type, and an updated connection lifecycle diagram.

## This change addresses the need by

- Bumping `@version` in `mix.exs` from `"0.2.0"` to `"0.3.0"`

### Changes included in v0.3.0

- Automatic reconnection with configurable backoff (#57, closes #6 and #7)
- `{:disconnect, reason, state}` callback return type (#58, closes #33)
- Updated connection lifecycle diagram (#56)