### PR TITLE
Fix connection lifecycle state diagram

### DIFF
--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -94,13 +94,14 @@ defmodule Parley do
       connecting --> connected: upgrade success
       connecting --> disconnected: error / timeout
 
-      connected --> disconnected: error / close / disconnect/1
+      connected --> disconnected: error / close / disconnect/1 / {:disconnect, ...}
       connected --> [*]: callback {:stop, ...}
 
       state disconnected {
           [*] --> handle_disconnect
-          handle_disconnect --> maybe_reconnect: {:ok, state} / {:reconnect, state}
+          handle_disconnect --> reconnecting: {:ok, state} / {:reconnect, state}
           handle_disconnect --> stay_disconnected: {:disconnect, state}
+          reconnecting --> [*]
       }
 
       state connected {
@@ -110,6 +111,8 @@ defmodule Parley do
           handle_frame --> waiting
           waiting --> handle_ping: ping received
           handle_ping --> waiting
+          waiting --> handle_info: process message
+          handle_info --> waiting
       }
 
       note right of connecting
@@ -123,9 +126,11 @@ defmodule Parley do
       end note
 
       note left of disconnected
-          handle_info/2 runs in all three
-          states. {:stop, ...} terminates
-          the process from any state.
+          handle_info/2 runs in all states.
+          {:disconnect, ...} transitions to
+          disconnected from any callback.
+          {:stop, ...} terminates the process
+          from any state.
       end note
   ```
 

--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -101,7 +101,6 @@ defmodule Parley do
           [*] --> handle_disconnect
           handle_disconnect --> reconnecting: {:ok, state} / {:reconnect, state}
           handle_disconnect --> stay_disconnected: {:disconnect, state}
-          reconnecting --> [*]
       }
 
       state connected {


### PR DESCRIPTION
## Why

The mermaid state diagram in the module doc for `Parley` had several inaccuracies that made it an incomplete representation of the actual connection lifecycle. Callbacks returning `{:disconnect, reason, state}` were not reflected, `handle_info/2` was missing from the connected state, and `maybe_reconnect` was a visual dead end with no outgoing transition.

## This change addresses the need by

- Adding `{:disconnect, ...}` to the `connected --> disconnected` outer transition label so it is clear that callback returns (not just `disconnect/1` calls) trigger the transition
- Adding `handle_info` to the `connected` composite state as an inner transition (`waiting --> handle_info --> waiting`) since it runs in all states and can return `{:push, ...}`, `{:disconnect, ...}`, etc.
- Renaming `maybe_reconnect` to `reconnecting` and adding a `reconnecting --> [*]` outgoing arrow so it visually connects back out of the disconnected composite state toward the next connection attempt
- Updating the note to mention that `{:disconnect, ...}` can transition to disconnected from any callback, and that `handle_info/2` runs in all states