### PR TITLE
Expand test coverage (#13)

### DIFF
--- a/test/parley_test.exs
+++ b/test/parley_test.exs
@@ -843,6 +843,81 @@ defmodule ParleyTest do
     end
   end
 
+  describe "large frames" do
+    test "echoes a large text frame", %{url: url} do
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      large_text = String.duplicate("a", 100_000)
+      :ok = Parley.send_frame(pid, {:text, large_text})
+      assert_receive {:frame, {:text, ^large_text}}, 5000
+
+      Parley.disconnect(pid)
+    end
+
+    test "echoes a large binary frame", %{url: url} do
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      large_binary = :crypto.strong_rand_bytes(100_000)
+      :ok = Parley.send_frame(pid, {:binary, large_binary})
+      assert_receive {:frame, {:binary, ^large_binary}}, 5000
+
+      Parley.disconnect(pid)
+    end
+  end
+
+  describe "concurrent sends" do
+    test "multiple callers can send frames concurrently", %{url: url} do
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      tasks =
+        for i <- 1..10 do
+          Task.async(fn ->
+            Parley.send_frame(pid, {:text, "msg-#{i}"})
+          end)
+        end
+
+      results = Task.await_many(tasks, 5000)
+      assert Enum.all?(results, &(&1 == :ok))
+
+      messages =
+        for _ <- 1..10 do
+          assert_receive {:frame, {:text, msg}}, 1000
+          msg
+        end
+
+      for i <- 1..10 do
+        assert "msg-#{i}" in messages
+      end
+
+      Parley.disconnect(pid)
+    end
+  end
+
+  describe "disconnect during connecting" do
+    test "disconnect while still in connecting state returns ok" do
+      # Start a TCP server that accepts connections but never responds
+      {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
+      {:ok, port} = :inet.port(listen)
+
+      {:ok, pid} =
+        Client.start_link(%{test_pid: self()},
+          url: "ws://127.0.0.1:#{port}/ws",
+          connect_timeout: 5000
+        )
+
+      # Disconnect immediately while still in :connecting state
+      assert :ok = Parley.disconnect(pid)
+      assert_receive {:disconnected, :closed}, 1000
+
+      assert Process.alive?(pid)
+      Parley.disconnect(pid)
+      :gen_tcp.close(listen)
+    end
+  end
+
   describe "options validation" do
     test "start_link without :url raises KeyError" do
       assert_raise KeyError, ~r/key :url not found/, fn ->


### PR DESCRIPTION
## Why:

Issue #13 identified gaps in test coverage for edge cases that are important for a production WebSocket client: handling of large payloads, concurrent access from multiple callers, and disconnection during the connecting state.

## This change addresses the need by:

Adding three new test groups to `test/parley_test.exs`:

- **Large frames** -- Sends 100KB text and binary payloads through the echo server to verify that Mint's internal frame handling works correctly for payloads that exceed typical frame sizes.
- **Concurrent sends** -- Spawns 10 async tasks that each call `Parley.send_frame/2` simultaneously, then verifies all calls return `:ok` and all 10 unique messages are echoed back. This validates that `gen_statem` correctly serializes concurrent `{:call, from}` events.
- **Disconnect during connecting** -- Uses a TCP server that accepts but never responds (keeping the client in `:connecting` state), then immediately calls `Parley.disconnect/1` and asserts it returns `:ok` with a `:closed` disconnect reason. This validates the `connecting({:call, from}, :disconnect, data)` code path.

Closes #13