### PR TITLE
Add async send_frame (cast-style)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Options passed to `Parley.start_link/3` or `Parley.start/3`:
 
 ### State Machine
 
-- **`:disconnected`** — Initial state. Triggers connection via internal event. Rejects sends with `{:error, :disconnected}`. When reconnection is enabled, schedules retry with exponential backoff via `handle_disconnect/2` return value and `:reconnect` option.
+- **`:disconnected`** — Initial state. Triggers connection via internal event. `send_frame/2` returns `{:error, :disconnected}`; `send_frame_async/2` silently drops the frame. When reconnection is enabled, schedules retry with exponential backoff via `handle_disconnect/2` return value and `:reconnect` option.
 - **`:connecting`** — TCP connected, WebSocket upgrade in progress. Sends are postponed (auto-retried on connect).
 - **`:connected`** — Active. Frames flow through callbacks. Pings auto-responded with pong. Resets reconnect attempt counter to 0 on entry.
 

--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -478,6 +478,23 @@ defmodule Parley do
   end
 
   @doc """
+  Sends a WebSocket frame to the server asynchronously (fire-and-forget).
+
+  Unlike `send_frame/2`, this does not wait for confirmation that the frame
+  was sent. It always returns `:ok` immediately. If the connection is not
+  in the `:connected` state, the frame is silently dropped.
+
+  ## Examples
+
+      :ok = Parley.send_frame_async(pid, {:text, "hello"})
+
+  """
+  @spec send_frame_async(:gen_statem.server_ref(), frame()) :: :ok
+  def send_frame_async(server, frame) do
+    :gen_statem.cast(server, {:send, frame})
+  end
+
+  @doc """
   Gracefully disconnects from the WebSocket server.
 
   Sends a WebSocket close frame and transitions the process to the

--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -115,8 +115,8 @@ defmodule Parley do
       }
 
       note right of connecting
-          send_frame/2 calls are queued
-          and replayed on connect
+          send_frame/2 and send_frame_async/2
+          are queued and replayed on connect
       end note
 
       note right of connected
@@ -137,8 +137,8 @@ defmodule Parley do
     Calls `c:handle_disconnect/2` when entering from another state. If reconnection is
     enabled, schedules a reconnect attempt with exponential backoff.
   - **`connecting`** — TCP connection established, waiting for the WebSocket upgrade
-    handshake to complete. Frames sent via `send_frame/2` during this state are
-    automatically queued and delivered once connected.
+    handshake to complete. Frames sent via `send_frame/2` or `send_frame_async/2`
+    during this state are automatically queued and delivered once connected.
   - **`connected`** — WebSocket upgrade complete. Calls `c:handle_connect/1` on entry,
     then `c:handle_frame/2` for each frame received from the server. Resets the
     reconnect attempt counter to 0.
@@ -481,8 +481,11 @@ defmodule Parley do
   Sends a WebSocket frame to the server asynchronously (fire-and-forget).
 
   Unlike `send_frame/2`, this does not wait for confirmation that the frame
-  was sent. It always returns `:ok` immediately. If the connection is not
-  in the `:connected` state, the frame is silently dropped.
+  was sent. It always returns `:ok` immediately.
+
+  While in the `:connecting` state, the frame is queued and delivered once
+  the connection completes (same as `send_frame/2`). If the process is in
+  the `:disconnected` state, the frame is silently dropped.
 
   ## Examples
 

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -300,8 +300,9 @@ defmodule Parley.Connection do
           {:ok, conn} ->
             {:keep_state, %{data | conn: conn, websocket: websocket}}
 
-          {:error, conn, _reason} ->
-            {:next_state, :disconnected, %{data | conn: conn}}
+          {:error, conn, reason} ->
+            {:next_state, :disconnected,
+             %{data | conn: conn, disconnect_reason: {:error, reason}}}
         end
 
       {:error, websocket, reason} ->

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -158,6 +158,10 @@ defmodule Parley.Connection do
     {:keep_state_and_data, [{:reply, from, {:error, :disconnected}}]}
   end
 
+  def disconnected(:cast, {:send, _frame}, _data) do
+    :keep_state_and_data
+  end
+
   def disconnected({:call, from}, :disconnect, data) do
     data = cancel_reconnect_timer(data)
     {:keep_state, data, [{:reply, from, :ok}]}
@@ -202,6 +206,10 @@ defmodule Parley.Connection do
   end
 
   def connecting({:call, _from}, {:send, _frame}, _data) do
+    {:keep_state_and_data, [:postpone]}
+  end
+
+  def connecting(:cast, {:send, _frame}, _data) do
     {:keep_state_and_data, [:postpone]}
   end
 
@@ -282,6 +290,23 @@ defmodule Parley.Connection do
 
       {:error, websocket, reason} ->
         {:keep_state, %{data | websocket: websocket}, [{:reply, from, {:error, reason}}]}
+    end
+  end
+
+  def connected(:cast, {:send, frame}, data) do
+    case Mint.WebSocket.encode(data.websocket, frame) do
+      {:ok, websocket, encoded} ->
+        case Mint.WebSocket.stream_request_body(data.conn, data.request_ref, encoded) do
+          {:ok, conn} ->
+            {:keep_state, %{data | conn: conn, websocket: websocket}}
+
+          {:error, conn, _reason} ->
+            {:next_state, :disconnected, %{data | conn: conn}}
+        end
+
+      {:error, websocket, reason} ->
+        Logger.warning("Failed to encode async frame: #{inspect(reason)}")
+        {:keep_state, %{data | websocket: websocket}}
     end
   end
 

--- a/test/parley_test.exs
+++ b/test/parley_test.exs
@@ -60,6 +60,65 @@ defmodule ParleyTest do
     end
   end
 
+  describe "async sending" do
+    test "send_frame_async sends frame and returns :ok immediately", %{url: url} do
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      assert :ok = Parley.send_frame_async(pid, {:text, "async hello"})
+      assert_receive {:frame, {:text, "async hello"}}, 1000
+
+      Parley.disconnect(pid)
+    end
+
+    test "send_frame_async returns :ok when disconnected", %{url: url} do
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      :ok = Parley.disconnect(pid)
+      assert_receive {:disconnected, :closed}, 1000
+
+      # Should return :ok (fire-and-forget) even when disconnected
+      assert :ok = Parley.send_frame_async(pid, {:text, "dropped"})
+    end
+
+    test "send_frame_async multiple frames in sequence", %{url: url} do
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      :ok = Parley.send_frame_async(pid, {:text, "one"})
+      :ok = Parley.send_frame_async(pid, {:text, "two"})
+      :ok = Parley.send_frame_async(pid, {:text, "three"})
+
+      assert_receive {:frame, {:text, "one"}}, 1000
+      assert_receive {:frame, {:text, "two"}}, 1000
+      assert_receive {:frame, {:text, "three"}}, 1000
+
+      Parley.disconnect(pid)
+    end
+
+    test "postponed send_frame_async is dropped after connect timeout" do
+      {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
+      {:ok, port} = :inet.port(listen)
+
+      {:ok, pid} =
+        Client.start_link(%{test_pid: self()},
+          url: "ws://127.0.0.1:#{port}/ws",
+          connect_timeout: 200
+        )
+
+      # Cast while still in :connecting state — will be postponed
+      :ok = Parley.send_frame_async(pid, {:text, "hello"})
+
+      # Eventually times out and transitions to disconnected
+      # The postponed cast should be silently dropped in disconnected state
+      assert_receive {:disconnected, :connect_timeout}, 1000
+
+      Parley.disconnect(pid)
+      :gen_tcp.close(listen)
+    end
+  end
+
   describe "disconnecting" do
     test "graceful disconnect invokes handle_disconnect", %{url: url} do
       {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)


### PR DESCRIPTION
## Why

The existing `Parley.send_frame/2` uses `:gen_statem.call` which blocks until the server processes the request. For fire-and-forget use cases (e.g. streaming telemetry, logging, or rapid message bursts where confirmation is unnecessary), a non-blocking variant avoids caller contention and simplifies application code.

Closes #20

## This change addresses the need by

- Adding `Parley.send_frame_async/2` which uses `:gen_statem.cast` to send frames without waiting for a reply, always returning `:ok` immediately
- Adding cast handlers in all three connection states: silently drops in `:disconnected`, postpones during `:connecting` (delivered once connected), and encodes/sends in `:connected`
- Adding tests covering: async send while connected, send while disconnected (fire-and-forget semantics), multiple sequential async sends, and postponed casts that timeout during connecting