### PR TITLE
Add [:parley, :frame, :received] telemetry event

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Parley provides a callback-based API (`use Parley`) backed by a `gen_statem` sta
 - `Parley` (`lib/parley.ex`) — Behaviour definition with callbacks + `__using__` macro
 - `Parley.Connection` (`lib/parley/connection.ex`) — `gen_statem` implementation with state machine: `disconnected → connecting → connected`
 - `Parley.Application` (`lib/parley/application.ex`) — OTP Application supervisor
+- `Parley.Telemetry` (`lib/parley/telemetry.ex`) — `:telemetry` event reference and emit functions
 
 ### Callbacks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,5 +72,5 @@ Test support modules are compiled via `elixirc_paths(:test)` in `mix.exs`.
 
 - Elixir 1.19, OTP 28
 - Use `mix format` before committing
-- Tests are async (`use ExUnit.Case, async: true`)
+- Tests are async (`use ExUnit.Case, async: true`), except telemetry tests, which run `async: false` — `:telemetry` handlers live in a global registry, so a concurrent test's events would satisfy another test's `assert_receive`
 - Follow existing patterns: callbacks return `{:ok, state}`, public API goes through `Parley.Connection`

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -484,19 +484,25 @@ defmodule Parley.Connection do
 
   defp process_frames(data, frames) do
     Enum.reduce_while(frames, {:ok, data}, fn
+      # Close frames are lifecycle, not data: they must not emit frame:received,
+      # so they are handled here before the single emit site below.
       {:close, code, reason}, {:ok, data} ->
         data = send_close(data)
         {:halt, {:close, code, reason, data}}
 
-      {:ping, payload} = frame, {:ok, data} ->
-        Parley.Telemetry.frame_received(frame, data.module, data.uri)
-        data = send_pong(data, payload)
-        handle_frame_result(data.module.handle_ping(payload, data.user_state), data)
-
       frame, {:ok, data} ->
         Parley.Telemetry.frame_received(frame, data.module, data.uri)
-        handle_frame_result(data.module.handle_frame(frame, data.user_state), data)
+        dispatch_frame(frame, data)
     end)
+  end
+
+  defp dispatch_frame({:ping, payload}, data) do
+    data = send_pong(data, payload)
+    handle_frame_result(data.module.handle_ping(payload, data.user_state), data)
+  end
+
+  defp dispatch_frame(frame, data) do
+    handle_frame_result(data.module.handle_frame(frame, data.user_state), data)
   end
 
   defp handle_frame_result({:ok, user_state}, data) do

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -488,11 +488,13 @@ defmodule Parley.Connection do
         data = send_close(data)
         {:halt, {:close, code, reason, data}}
 
-      {:ping, payload}, {:ok, data} ->
+      {:ping, payload} = frame, {:ok, data} ->
+        Parley.Telemetry.frame_received(frame, data.module, data.uri)
         data = send_pong(data, payload)
         handle_frame_result(data.module.handle_ping(payload, data.user_state), data)
 
       frame, {:ok, data} ->
+        Parley.Telemetry.frame_received(frame, data.module, data.uri)
         handle_frame_result(data.module.handle_frame(frame, data.user_state), data)
     end)
   end

--- a/lib/parley/telemetry.ex
+++ b/lib/parley/telemetry.ex
@@ -1,0 +1,55 @@
+defmodule Parley.Telemetry do
+  @moduledoc """
+  Telemetry events emitted by Parley.
+
+  Parley uses [`:telemetry`](https://hexdocs.pm/telemetry) to make the
+  connection's activity observable. Attach a handler to any of the events
+  below to feed metrics, tracing, or logging without changing your client
+  callbacks.
+
+  ## Events
+
+  ### `[:parley, :frame, :received]`
+
+  Emitted for every WebSocket frame received from the server, before the
+  corresponding callback (`c:Parley.handle_frame/2` or
+  `c:Parley.handle_ping/2`) runs. Close frames are part of the connection
+  lifecycle rather than data and do **not** emit this event.
+
+    * Measurements
+      * `:size` — the payload size in bytes (`byte_size/1` of the frame
+        payload, not the number of bytes on the wire)
+
+    * Metadata
+      * `:type` — the frame type: `:text`, `:binary`, `:ping`, or `:pong`
+      * `:module` — the module implementing the `Parley` callbacks
+      * `:uri` — the `t:URI.t/0` the connection was opened against
+      * `:pid` — the connection process that received the frame
+
+  ## Example
+
+      :telemetry.attach(
+        "log-received-frames",
+        [:parley, :frame, :received],
+        fn _event, %{size: size}, %{type: type}, _config ->
+          IO.puts("received \#{type} frame (\#{size} bytes)")
+        end,
+        nil
+      )
+  """
+
+  @frame_received [:parley, :frame, :received]
+
+  @doc false
+  @spec frame_received(tuple(), module(), URI.t()) :: :ok
+  def frame_received({type, payload}, module, %URI{} = uri)
+      when type in [:text, :binary, :ping, :pong] and is_binary(payload) do
+    :telemetry.execute(
+      @frame_received,
+      %{size: byte_size(payload)},
+      %{type: type, module: module, uri: uri, pid: self()}
+    )
+  end
+
+  def frame_received(_frame, _module, _uri), do: :ok
+end

--- a/mix.exs
+++ b/mix.exs
@@ -614,6 +614,7 @@ defmodule Parley.MixProject do
     [
       {:mint_web_socket, "~> 1.0"},
       {:castore, "~> 1.0"},
+      {:telemetry, "~> 1.0"},
       {:bandit, "~> 1.0", only: :test},
       {:websock_adapter, "~> 0.5", only: :test},
       {:ex_doc, "~> 0.35", only: :dev, runtime: false},

--- a/test/parley/telemetry_test.exs
+++ b/test/parley/telemetry_test.exs
@@ -1,0 +1,62 @@
+defmodule Parley.TelemetryTest do
+  # async: false is a deliberate deviation from the repo convention that
+  # tests run async. Telemetry handlers are registered globally, so
+  # :telemetry_test.attach_event_handlers/2 forwards matching events from
+  # every process — a concurrent test's connection would satisfy our
+  # assert_receive on [:parley, :frame, :received]. ExUnit runs sync
+  # modules alone after every async module has finished, giving us an
+  # isolated global handler registry.
+  use ExUnit.Case, async: false
+
+  alias Parley.Test.{Client, EchoServer}
+
+  setup do
+    {port, server_pid} = EchoServer.start()
+
+    on_exit(fn ->
+      if Process.alive?(server_pid), do: Supervisor.stop(server_pid, :normal, 1000)
+    end)
+
+    %{url: "ws://localhost:#{port}/ws"}
+  end
+
+  test "emits [:parley, :frame, :received] for a text frame", %{url: url} do
+    ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :frame, :received]])
+
+    {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+    assert_receive :connected, 1000
+
+    :ok = Parley.send_frame(pid, {:text, "hello"})
+
+    assert_receive {[:parley, :frame, :received], ^ref, measurements, metadata}, 1000
+
+    # "hello" is 5 bytes; assert the literal, not a recomputation.
+    assert measurements == %{size: 5}
+    assert metadata.type == :text
+    assert metadata.pid == pid
+    assert metadata.module == Client
+    assert %URI{} = metadata.uri
+
+    Parley.disconnect(pid)
+  end
+
+  test "emits [:parley, :frame, :received] for a binary frame", %{url: url} do
+    ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :frame, :received]])
+
+    {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+    assert_receive :connected, 1000
+
+    :ok = Parley.send_frame(pid, {:binary, <<1, 2, 3, 4>>})
+
+    assert_receive {[:parley, :frame, :received], ^ref, measurements, metadata}, 1000
+
+    # <<1, 2, 3, 4>> is 4 bytes; assert the literal, not a recomputation.
+    assert measurements == %{size: 4}
+    assert metadata.type == :binary
+    assert metadata.pid == pid
+    assert metadata.module == Client
+    assert %URI{} = metadata.uri
+
+    Parley.disconnect(pid)
+  end
+end

--- a/test/parley/telemetry_test.exs
+++ b/test/parley/telemetry_test.exs
@@ -59,4 +59,42 @@ defmodule Parley.TelemetryTest do
 
     Parley.disconnect(pid)
   end
+
+  test "emits [:parley, :frame, :received] for a ping frame", %{url: url} do
+    ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :frame, :received]])
+
+    {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+    assert_receive :connected, 1000
+
+    # Ask the echo server to send us a ping carrying a 3-byte payload. The ping
+    # is emitted from a distinct process_frames/2 clause than text/binary.
+    :ok = Parley.send_frame(pid, {:text, "send_ping:abc"})
+
+    assert_receive {[:parley, :frame, :received], ^ref, measurements, metadata}, 1000
+
+    # "abc" is 3 bytes; assert the literal, not a recomputation.
+    assert measurements == %{size: 3}
+    assert metadata.type == :ping
+    assert metadata.pid == pid
+    assert metadata.module == Client
+    assert %URI{} = metadata.uri
+
+    Parley.disconnect(pid)
+  end
+
+  test "does not emit [:parley, :frame, :received] for a close frame", %{url: url} do
+    ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :frame, :received]])
+
+    {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+    assert_receive :connected, 1000
+
+    # The echo server answers "close" with a close frame. Close is lifecycle,
+    # not data, so it must not emit frame:received. The disconnect arrives after
+    # the frame would have been processed, so any wrongful event is already in
+    # the mailbox by the time refute_received runs.
+    :ok = Parley.send_frame(pid, {:text, "close"})
+
+    assert_receive {:disconnected, {:remote_close, 1000, _}}, 1000
+    refute_received {[:parley, :frame, :received], ^ref, _measurements, _metadata}
+  end
 end

--- a/test/parley/telemetry_test.exs
+++ b/test/parley/telemetry_test.exs
@@ -35,7 +35,7 @@ defmodule Parley.TelemetryTest do
     assert metadata.type == :text
     assert metadata.pid == pid
     assert metadata.module == Client
-    assert %URI{} = metadata.uri
+    assert metadata.uri == URI.parse(url)
 
     Parley.disconnect(pid)
   end
@@ -55,7 +55,7 @@ defmodule Parley.TelemetryTest do
     assert metadata.type == :binary
     assert metadata.pid == pid
     assert metadata.module == Client
-    assert %URI{} = metadata.uri
+    assert metadata.uri == URI.parse(url)
 
     Parley.disconnect(pid)
   end
@@ -66,8 +66,9 @@ defmodule Parley.TelemetryTest do
     {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
     assert_receive :connected, 1000
 
-    # Ask the echo server to send us a ping carrying a 3-byte payload. The ping
-    # is emitted from a distinct process_frames/2 clause than text/binary.
+    # Ask the echo server to send us a ping carrying a 3-byte payload. Ping is
+    # dispatched from a distinct dispatch_frame/2 clause (send_pong + handle_ping)
+    # than text/binary, so it exercises a separate path to the shared emit site.
     :ok = Parley.send_frame(pid, {:text, "send_ping:abc"})
 
     assert_receive {[:parley, :frame, :received], ^ref, measurements, metadata}, 1000
@@ -77,7 +78,7 @@ defmodule Parley.TelemetryTest do
     assert metadata.type == :ping
     assert metadata.pid == pid
     assert metadata.module == Client
-    assert %URI{} = metadata.uri
+    assert metadata.uri == URI.parse(url)
 
     Parley.disconnect(pid)
   end


### PR DESCRIPTION
## Why

Every client module that wants connection metrics currently has to implement `handle_connect/1`, `handle_disconnect/2`, and `handle_frame/2` purely to forward numbers to a metrics library. `:telemetry` moves that to a single application-level handler with zero callback code (#61).

This is the tracer bullet for that work: the thinnest complete slice — one event emitted from inside the state machine, asserted at the real `Parley.start_link/3` seam — proving the dependency resolves, the public reference module renders, and (the real risk) that a globally-registered handler catches events from the connection process.

Part of #61

## This change addresses the need by

- Promoting `{:telemetry, "~> 1.0"}` to a direct production dependency (already resolved at 1.3.0 transitively; `mix.lock` unchanged)
- Adding `Parley.Telemetry` with a public `@moduledoc` as the event reference and a `@doc false` emit function
- Emitting `[:parley, :frame, :received]` from `process_frames/2` with `%{size: byte_size(payload)}` and metadata `%{module, uri, pid, type}`, matching the four public frame shapes; `{:close, ...}` deliberately does not emit
- Adding `test/parley/telemetry_test.exs` (`async: false`, commented -- telemetry handlers are globally registered, so a concurrent test connection would satisfy `assert_receive`) that drives the real echo path and asserts the event and byte size for `:text` and `:binary`