### PR TITLE
Unify send paths and fix sync send-failure disconnect reason

### DIFF
--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -278,36 +278,30 @@ defmodule Parley.Connection do
   end
 
   def connected({:call, from}, {:send, frame}, data) do
-    case Mint.WebSocket.encode(data.websocket, frame) do
-      {:ok, websocket, encoded} ->
-        case Mint.WebSocket.stream_request_body(data.conn, data.request_ref, encoded) do
-          {:ok, conn} ->
-            {:keep_state, %{data | conn: conn, websocket: websocket}, [{:reply, from, :ok}]}
+    case send_frame_internal(data, frame) do
+      {:ok, data} ->
+        {:keep_state, data, [{:reply, from, :ok}]}
 
-          {:error, conn, reason} ->
-            {:next_state, :disconnected, %{data | conn: conn}, [{:reply, from, {:error, reason}}]}
-        end
+      {:error, :encode, data, reason} ->
+        {:keep_state, data, [{:reply, from, {:error, reason}}]}
 
-      {:error, websocket, reason} ->
-        {:keep_state, %{data | websocket: websocket}, [{:reply, from, {:error, reason}}]}
+      {:error, :send, data, reason} ->
+        {:next_state, :disconnected, %{data | disconnect_reason: {:error, reason}},
+         [{:reply, from, {:error, reason}}]}
     end
   end
 
   def connected(:cast, {:send, frame}, data) do
-    case Mint.WebSocket.encode(data.websocket, frame) do
-      {:ok, websocket, encoded} ->
-        case Mint.WebSocket.stream_request_body(data.conn, data.request_ref, encoded) do
-          {:ok, conn} ->
-            {:keep_state, %{data | conn: conn, websocket: websocket}}
+    case send_frame_internal(data, frame) do
+      {:ok, data} ->
+        {:keep_state, data}
 
-          {:error, conn, reason} ->
-            {:next_state, :disconnected,
-             %{data | conn: conn, disconnect_reason: {:error, reason}}}
-        end
-
-      {:error, websocket, reason} ->
+      {:error, :encode, data, reason} ->
         Logger.warning("Failed to encode async frame: #{inspect(reason)}")
-        {:keep_state, %{data | websocket: websocket}}
+        {:keep_state, data}
+
+      {:error, :send, data, reason} ->
+        {:next_state, :disconnected, %{data | disconnect_reason: {:error, reason}}}
     end
   end
 

--- a/test/parley_test.exs
+++ b/test/parley_test.exs
@@ -147,6 +147,31 @@ defmodule ParleyTest do
 
       assert :ok = Parley.disconnect(pid)
     end
+
+    test "synchronous send failure reports the transport error to handle_disconnect",
+         %{url: url} do
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      # A synchronous stream_request_body failure is near-impossible to trigger
+      # through real I/O: TCP writes buffer, so a dead socket surfaces via the
+      # info path, not the send call. Inject a closed Mint connection so the next
+      # send fails synchronously at the transport, exercising the
+      # connected({:call, ...}, {:send, ...}) send-error branch. Regression test
+      # for #287, where that branch omitted disconnect_reason and handle_disconnect
+      # saw a stale reason instead of the real transport error.
+      {:connected, data} = :sys.get_state(pid)
+      {:ok, closed_conn} = Mint.HTTP.close(data.conn)
+      :sys.replace_state(pid, fn {_state, d} -> {:connected, %{d | conn: closed_conn}} end)
+
+      # The caller receives the real transport error synchronously...
+      assert {:error, %Mint.TransportError{reason: :closed}} =
+               Parley.send_frame(pid, {:text, "will fail"})
+
+      # ...and handle_disconnect sees that same reason, not a stale/default one.
+      assert_receive {:disconnected, {:error, %Mint.TransportError{reason: :closed}}}, 1000
+      assert Process.alive?(pid)
+    end
   end
 
   describe "connection errors" do


### PR DESCRIPTION
## Why

A synchronous `send_frame/2` that fails at the transport reports `:closed` to `handle_disconnect/2` instead of the real `{:error, reason}`, because the sync failure branch never set `disconnect_reason` and it defaulted to `:closed`. A client keying reconnect logic on the reason cannot tell a transport failure from a clean close (#69). Separately, the two public send clauses duplicate the encode-then-stream logic, which the upcoming frame telemetry needs unified into one emit site.

Closes #69

## This change addresses the need by

- Pointing both `connected({:call, from}, {:send, frame})` and `connected(:cast, {:send, frame})` at the existing `send_frame_internal/2`, removing the duplicated encode/stream logic
- Setting `disconnect_reason: {:error, reason}` on the sync send-failure path, matching the async path
- Preserving all other observable behaviour, including the sync/async encode-error asymmetry (verified branch-by-branch)
- Conscious side effect: routing through `send_frame_internal/2` retains the post-encode `websocket` on the send-error path; benign because `disconnected(:enter, ...)` resets `websocket: nil` before `handle_disconnect/2` runs
- Acknowledged test gap: the fix has no deterministic driver -- reaching it needs `stream_request_body/3` itself to fail, which the suite cannot force -- so it ships as a reviewed change with no fabricated test