### PR TITLE
Trap exits and intercept EXIT signals

### DIFF
--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -34,10 +34,11 @@ defmodule Parley.Connection do
 
   @impl true
   def init({module, {url, user_state, opts}}) do
-    # Trap exits so a linked process (e.g. a supervisor sending :shutdown, or a
-    # user-linked worker) is delivered as a message we can react to, rather than
-    # taking the process down with no chance to clean up. The intercept clauses
-    # in each state preserve the untrapped behaviour for non-parent EXITs.
+    # Trap exits so that on shutdown gen_statem terminates cleanly (running
+    # terminate/3) instead of being killed by the signal. gen_statem consumes
+    # the *parent's* EXIT in its own loop; the intercept clauses in each state
+    # handle only *non-parent* EXITs (a linked worker, the transport port),
+    # preserving the untrapped behaviour for those.
     Process.flag(:trap_exit, true)
 
     case module.init(user_state) do

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -144,20 +144,8 @@ defmodule Parley.Connection do
     end
   end
 
-  # We trap exits (see init/1), so we must replicate the default OTP behaviour
-  # for a linked process' EXIT ourselves: ignore a :normal exit, die with the
-  # reason on an abnormal one. There is deliberately no is_pid guard: the
-  # transport socket is a linked *port*, not a pid, so matching its EXIT here is
-  # what makes an abnormal transport death stop us exactly as it did before we
-  # trapped exits (an unguarded port EXIT would otherwise fall through to the
-  # stream/handle_info and leave us alive in a broken state). These same clauses
-  # appear in connecting/connected; this note is the shared explanation.
-  def disconnected(:info, {:EXIT, _from, :normal}, _data) do
-    :keep_state_and_data
-  end
-
   def disconnected(:info, {:EXIT, _from, reason}, data) do
-    {:stop, reason, data}
+    handle_linked_exit(reason, data)
   end
 
   def disconnected(:info, message, data) do
@@ -200,13 +188,8 @@ defmodule Parley.Connection do
     {:next_state, :disconnected, %{data | disconnect_reason: :connect_timeout}}
   end
 
-  # EXIT interception (see the note on disconnected/3 for why there is no guard).
-  def connecting(:info, {:EXIT, _from, :normal}, _data) do
-    :keep_state_and_data
-  end
-
   def connecting(:info, {:EXIT, _from, reason}, data) do
-    {:stop, reason, data}
+    handle_linked_exit(reason, data)
   end
 
   def connecting(:info, message, data) do
@@ -296,13 +279,8 @@ defmodule Parley.Connection do
     {:next_state, :disconnected, data}
   end
 
-  # EXIT interception (see the note on disconnected/3 for why there is no guard).
-  def connected(:info, {:EXIT, _from, :normal}, _data) do
-    :keep_state_and_data
-  end
-
   def connected(:info, {:EXIT, _from, reason}, data) do
-    {:stop, reason, data}
+    handle_linked_exit(reason, data)
   end
 
   def connected(:info, message, data) do
@@ -598,6 +576,16 @@ defmodule Parley.Connection do
     if data.conn, do: Mint.HTTP.close(data.conn)
     {:stop, reason, %{data | user_state: user_state, conn: nil}}
   end
+
+  # We trap exits (see init/1), so we replicate OTP's default behaviour for a
+  # linked process' EXIT: ignore a :normal exit, die with the reason on an
+  # abnormal one. There is deliberately no is_pid guard — the transport socket is
+  # a linked *port*, not a pid, so an abnormal port death must stop us exactly as
+  # it did before we trapped exits (an unguarded port EXIT would otherwise fall
+  # through to stream/handle_info and leave us alive in a broken state). Every
+  # state's non-parent {:EXIT, _, _} clause delegates here.
+  defp handle_linked_exit(:normal, _data), do: :keep_state_and_data
+  defp handle_linked_exit(reason, data), do: {:stop, reason, data}
 
   defp send_frame_internal(data, frame) do
     case Mint.WebSocket.encode(data.websocket, frame) do

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -34,6 +34,12 @@ defmodule Parley.Connection do
 
   @impl true
   def init({module, {url, user_state, opts}}) do
+    # Trap exits so a linked process (e.g. a supervisor sending :shutdown, or a
+    # user-linked worker) is delivered as a message we can react to, rather than
+    # taking the process down with no chance to clean up. The intercept clauses
+    # in each state preserve the untrapped behaviour for non-parent EXITs.
+    Process.flag(:trap_exit, true)
+
     case module.init(user_state) do
       {:ok, user_state} ->
         uri = URI.parse(url)
@@ -137,6 +143,19 @@ defmodule Parley.Connection do
     end
   end
 
+  # An untrapped process ignores a linked process exiting :normal, so we must
+  # too now that we trap exits. is_pid guards so a port EXIT (we own the
+  # transport) is not swallowed here and instead falls through to handle_info.
+  def disconnected(:info, {:EXIT, pid, :normal}, _data) when is_pid(pid) do
+    :keep_state_and_data
+  end
+
+  # An untrapped process dies when a linked process exits abnormally; propagate
+  # the same reason to preserve that behaviour.
+  def disconnected(:info, {:EXIT, pid, reason}, data) when is_pid(pid) do
+    {:stop, reason, data}
+  end
+
   def disconnected(:info, message, data) do
     case data.module.handle_info(message, data.user_state) do
       {:ok, user_state} ->
@@ -175,6 +194,19 @@ defmodule Parley.Connection do
 
   def connecting(:state_timeout, :connect_timeout, data) do
     {:next_state, :disconnected, %{data | disconnect_reason: :connect_timeout}}
+  end
+
+  # An untrapped process ignores a linked process exiting :normal, so we must
+  # too now that we trap exits. is_pid guards so a port EXIT (we own the
+  # transport) is not swallowed here and instead falls through to the stream.
+  def connecting(:info, {:EXIT, pid, :normal}, _data) when is_pid(pid) do
+    :keep_state_and_data
+  end
+
+  # An untrapped process dies when a linked process exits abnormally; propagate
+  # the same reason to preserve that behaviour.
+  def connecting(:info, {:EXIT, pid, reason}, data) when is_pid(pid) do
+    {:stop, reason, data}
   end
 
   def connecting(:info, message, data) do
@@ -262,6 +294,19 @@ defmodule Parley.Connection do
 
   def connected(:internal, :send_failed, data) do
     {:next_state, :disconnected, data}
+  end
+
+  # An untrapped process ignores a linked process exiting :normal, so we must
+  # too now that we trap exits. is_pid guards so a port EXIT (we own the
+  # transport) is not swallowed here and instead falls through to the stream.
+  def connected(:info, {:EXIT, pid, :normal}, _data) when is_pid(pid) do
+    :keep_state_and_data
+  end
+
+  # An untrapped process dies when a linked process exits abnormally; propagate
+  # the same reason to preserve that behaviour.
+  def connected(:info, {:EXIT, pid, reason}, data) when is_pid(pid) do
+    {:stop, reason, data}
   end
 
   def connected(:info, message, data) do

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -143,16 +143,19 @@ defmodule Parley.Connection do
     end
   end
 
-  # An untrapped process ignores a linked process exiting :normal, so we must
-  # too now that we trap exits. is_pid guards so a port EXIT (we own the
-  # transport) is not swallowed here and instead falls through to handle_info.
-  def disconnected(:info, {:EXIT, pid, :normal}, _data) when is_pid(pid) do
+  # We trap exits (see init/1), so we must replicate the default OTP behaviour
+  # for a linked process' EXIT ourselves: ignore a :normal exit, die with the
+  # reason on an abnormal one. There is deliberately no is_pid guard: the
+  # transport socket is a linked *port*, not a pid, so matching its EXIT here is
+  # what makes an abnormal transport death stop us exactly as it did before we
+  # trapped exits (an unguarded port EXIT would otherwise fall through to the
+  # stream/handle_info and leave us alive in a broken state). These same clauses
+  # appear in connecting/connected; this note is the shared explanation.
+  def disconnected(:info, {:EXIT, _from, :normal}, _data) do
     :keep_state_and_data
   end
 
-  # An untrapped process dies when a linked process exits abnormally; propagate
-  # the same reason to preserve that behaviour.
-  def disconnected(:info, {:EXIT, pid, reason}, data) when is_pid(pid) do
+  def disconnected(:info, {:EXIT, _from, reason}, data) do
     {:stop, reason, data}
   end
 
@@ -196,16 +199,12 @@ defmodule Parley.Connection do
     {:next_state, :disconnected, %{data | disconnect_reason: :connect_timeout}}
   end
 
-  # An untrapped process ignores a linked process exiting :normal, so we must
-  # too now that we trap exits. is_pid guards so a port EXIT (we own the
-  # transport) is not swallowed here and instead falls through to the stream.
-  def connecting(:info, {:EXIT, pid, :normal}, _data) when is_pid(pid) do
+  # EXIT interception (see the note on disconnected/3 for why there is no guard).
+  def connecting(:info, {:EXIT, _from, :normal}, _data) do
     :keep_state_and_data
   end
 
-  # An untrapped process dies when a linked process exits abnormally; propagate
-  # the same reason to preserve that behaviour.
-  def connecting(:info, {:EXIT, pid, reason}, data) when is_pid(pid) do
+  def connecting(:info, {:EXIT, _from, reason}, data) do
     {:stop, reason, data}
   end
 
@@ -296,16 +295,12 @@ defmodule Parley.Connection do
     {:next_state, :disconnected, data}
   end
 
-  # An untrapped process ignores a linked process exiting :normal, so we must
-  # too now that we trap exits. is_pid guards so a port EXIT (we own the
-  # transport) is not swallowed here and instead falls through to the stream.
-  def connected(:info, {:EXIT, pid, :normal}, _data) when is_pid(pid) do
+  # EXIT interception (see the note on disconnected/3 for why there is no guard).
+  def connected(:info, {:EXIT, _from, :normal}, _data) do
     :keep_state_and_data
   end
 
-  # An untrapped process dies when a linked process exits abnormally; propagate
-  # the same reason to preserve that behaviour.
-  def connected(:info, {:EXIT, pid, reason}, data) when is_pid(pid) do
+  def connected(:info, {:EXIT, _from, reason}, data) do
     {:stop, reason, data}
   end
 

--- a/test/parley_test.exs
+++ b/test/parley_test.exs
@@ -984,4 +984,96 @@ defmodule ParleyTest do
       end
     end
   end
+
+  describe "linked process exits" do
+    defmodule LinkedExitClient do
+      @moduledoc false
+      use Parley
+
+      @impl true
+      def handle_connect(%{test_pid: pid} = state) do
+        send(pid, :connected)
+        {:ok, state}
+      end
+
+      @impl true
+      def handle_frame(frame, %{test_pid: pid} = state) do
+        send(pid, {:frame, frame})
+        {:ok, state}
+      end
+
+      # Spawns a process linked to the connection process (self/0 here is the
+      # connection) that exits with the given reason once told to :go.
+      @impl true
+      def handle_info({:spawn_link, exit_reason}, %{test_pid: pid} = state) do
+        child =
+          spawn_link(fn ->
+            receive do
+              :go -> exit(exit_reason)
+            end
+          end)
+
+        send(pid, {:linked, child})
+        {:ok, state}
+      end
+
+      # The EXIT intercept clauses must swallow linked-process EXITs before they
+      # reach here; anything that lands in handle_info is a leak we report so the
+      # test can catch it.
+      def handle_info(message, %{test_pid: pid} = state) do
+        send(pid, {:unexpected_info, message})
+        {:ok, state}
+      end
+
+      @impl true
+      def handle_disconnect(reason, %{test_pid: pid} = state) do
+        send(pid, {:disconnected, reason})
+        {:ok, state}
+      end
+    end
+
+    test "a linked process exiting :normal does not kill the connection", %{url: url} do
+      Process.flag(:trap_exit, true)
+
+      {:ok, conn} = Parley.start_link(LinkedExitClient, %{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      send(conn, {:spawn_link, :normal})
+      assert_receive {:linked, child}, 1000
+
+      send(child, :go)
+
+      # The connection must survive the linked :normal exit. Prove liveness with
+      # a synchronous round-trip through the echo server; the call would fail if
+      # the process had died.
+      :ok = Parley.send_frame(conn, {:text, "still alive"})
+      assert_receive {:frame, {:text, "still alive"}}, 1000
+
+      # The EXIT must have been intercepted, not surfaced to handle_info/2, and
+      # must not have taken the connection down.
+      refute_received {:unexpected_info, {:EXIT, ^child, :normal}}
+      refute_received {:EXIT, ^conn, _reason}
+      assert Process.alive?(conn)
+
+      Parley.disconnect(conn)
+    end
+
+    test "a linked process exiting abnormally kills the connection with that reason",
+         %{url: url} do
+      Process.flag(:trap_exit, true)
+
+      {:ok, conn} = Parley.start_link(LinkedExitClient, %{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      send(conn, {:spawn_link, :boom})
+      assert_receive {:linked, child}, 1000
+
+      send(child, :go)
+
+      # An untrapped process would die with the linked process's exit reason;
+      # the connection must go down with the same reason.
+      assert_receive {:EXIT, ^conn, :boom}, 1000
+      refute Process.alive?(conn)
+    end
+  end
 end


### PR DESCRIPTION
## Why

Without `trap_exit`, a supervisor `exit(pid, :shutdown)` kills the connection outright -- no `terminate/3`, so no chance to close a lifecycle span. The telemetry spans in #61 need `terminate/3` to run on shutdown. Turning trapping on must not change any existing behaviour.

Part of #61

## This change addresses the need by

- Setting `Process.flag(:trap_exit, true)` in `init/1`
- Adding, in each state before the generic `:info` clause, two EXIT intercept clauses: a `:normal` exit is ignored, any other reason stops with that reason -- reproducing what an untrapped process does with a linked process's exit signal
- Using no `is_pid/1` guard: review plus an empirical probe showed the `ws://` socket is a linked *port*, so a guard would deflect an abnormal port EXIT into `handle_info/2` and leave a broken connection alive instead of stopping; without it, port and pid EXITs both match the untrapped baseline
- Accepting two deltas inherent to trapping (documented, not fixable by clauses): a parent exiting `:normal` now stops the child (supervisors exit `:shutdown`, so the supervised path is unaffected), and an abnormal non-parent pid exit now emits a `gen_statem` crash-report log
- Adding tests that drive real `spawn_link` + real exits; the `:normal` case proves the connection still works via an echo round-trip