### PR TITLE
Drop leftover transport messages in disconnected state

### DIFF
--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -151,12 +151,12 @@ defmodule Parley.Connection do
   # Leftover transport frames (e.g. a server close frame still in the mailbox
   # after we transitioned to :disconnected) must be consumed here, not leaked to
   # the client's handle_info/2 as raw wire bytes.
-  def disconnected(:info, {:tcp, _socket, _data}, _state), do: :keep_state_and_data
-  def disconnected(:info, {:tcp_closed, _socket}, _state), do: :keep_state_and_data
-  def disconnected(:info, {:tcp_error, _socket, _reason}, _state), do: :keep_state_and_data
-  def disconnected(:info, {:ssl, _socket, _data}, _state), do: :keep_state_and_data
-  def disconnected(:info, {:ssl_closed, _socket}, _state), do: :keep_state_and_data
-  def disconnected(:info, {:ssl_error, _socket, _reason}, _state), do: :keep_state_and_data
+  def disconnected(:info, {:tcp, _socket, _bytes}, _data), do: :keep_state_and_data
+  def disconnected(:info, {:tcp_closed, _socket}, _data), do: :keep_state_and_data
+  def disconnected(:info, {:tcp_error, _socket, _reason}, _data), do: :keep_state_and_data
+  def disconnected(:info, {:ssl, _socket, _bytes}, _data), do: :keep_state_and_data
+  def disconnected(:info, {:ssl_closed, _socket}, _data), do: :keep_state_and_data
+  def disconnected(:info, {:ssl_error, _socket, _reason}, _data), do: :keep_state_and_data
 
   def disconnected(:info, message, data) do
     case data.module.handle_info(message, data.user_state) do

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -150,7 +150,9 @@ defmodule Parley.Connection do
 
   # Leftover transport frames (e.g. a server close frame still in the mailbox
   # after we transitioned to :disconnected) must be consumed here, not leaked to
-  # the client's handle_info/2 as raw wire bytes.
+  # the client's handle_info/2 as raw wire bytes. Only :disconnected drops them:
+  # in :connecting/:connected they belong to the live conn and are consumed by
+  # Mint.WebSocket.stream/2, but here conn is nil so nothing else would.
   def disconnected(:info, {:tcp, _socket, _bytes}, _data), do: :keep_state_and_data
   def disconnected(:info, {:tcp_closed, _socket}, _data), do: :keep_state_and_data
   def disconnected(:info, {:tcp_error, _socket, _reason}, _data), do: :keep_state_and_data

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -148,6 +148,16 @@ defmodule Parley.Connection do
     handle_linked_exit(reason, data)
   end
 
+  # Leftover transport frames (e.g. a server close frame still in the mailbox
+  # after we transitioned to :disconnected) must be consumed here, not leaked to
+  # the client's handle_info/2 as raw wire bytes.
+  def disconnected(:info, {:tcp, _socket, _data}, _state), do: :keep_state_and_data
+  def disconnected(:info, {:tcp_closed, _socket}, _state), do: :keep_state_and_data
+  def disconnected(:info, {:tcp_error, _socket, _reason}, _state), do: :keep_state_and_data
+  def disconnected(:info, {:ssl, _socket, _data}, _state), do: :keep_state_and_data
+  def disconnected(:info, {:ssl_closed, _socket}, _state), do: :keep_state_and_data
+  def disconnected(:info, {:ssl_error, _socket, _reason}, _state), do: :keep_state_and_data
+
   def disconnected(:info, message, data) do
     case data.module.handle_info(message, data.user_state) do
       {:ok, user_state} ->

--- a/test/parley/disconnect_return_test.exs
+++ b/test/parley/disconnect_return_test.exs
@@ -330,9 +330,6 @@ defmodule Parley.DisconnectReturnTest do
         end
 
         @impl true
-        def handle_frame(_frame, state), do: {:ok, state}
-
-        @impl true
         def handle_disconnect(reason, %{test_pid: pid} = state) do
           send(pid, {:disconnected, reason})
           {:ok, state}

--- a/test/parley/disconnect_return_test.exs
+++ b/test/parley/disconnect_return_test.exs
@@ -290,6 +290,8 @@ defmodule Parley.DisconnectReturnTest do
           {:ok, state}
         end
 
+        def handle_info(_message, state), do: {:ok, state}
+
         @impl true
         def handle_disconnect(reason, %{test_pid: pid} = state) do
           send(pid, {:disconnected, reason, state})
@@ -312,6 +314,54 @@ defmodule Parley.DisconnectReturnTest do
       assert_receive {:disconnected, :done, %{disconnected_by_frame: true}}, 1000
 
       assert Process.alive?(pid)
+      Parley.disconnect(pid)
+    end
+  end
+
+  describe "leftover transport messages in :disconnected state" do
+    test "stray transport frame is dropped and never reaches handle_info/2", %{url: url} do
+      defmodule TransportLeakClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_frame(_frame, state), do: {:ok, state}
+
+        @impl true
+        def handle_disconnect(reason, %{test_pid: pid} = state) do
+          send(pid, {:disconnected, reason})
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_info(message, %{test_pid: pid} = state) do
+          send(pid, {:client_info, message})
+          {:ok, state}
+        end
+      end
+
+      {:ok, pid} =
+        Parley.start_link(TransportLeakClient, %{test_pid: self()}, url: url)
+
+      assert_receive :connected, 1000
+
+      # Park the connection in :disconnected (default reconnect: false).
+      :ok = Parley.disconnect(pid)
+      assert_receive {:disconnected, :closed}, 1000
+
+      # Simulate a server close frame still sitting in the mailbox that arrives
+      # after the transition to :disconnected.
+      send(pid, {:tcp, :fake_socket, <<136, 2, 3, 232>>})
+
+      # The library must consume it; the client callback must never see it.
+      refute_receive {:client_info, {:tcp, _, _}}, 200
+      assert Process.alive?(pid)
+
       Parley.disconnect(pid)
     end
   end


### PR DESCRIPTION
## Why

In the `:disconnected` state, the generic `:info` clause forwarded every message to the client's `handle_info/2`, including leftover raw transport messages. After a disconnect, a server close frame can still be in the mailbox and arrive after the process has transitioned to `:disconnected`, delivered as `{:tcp, port, <<136, 2, 3, 232>>}` (a WebSocket close frame). It was then handed to user code that never expects wire bytes, raising a `FunctionClauseError` in clients whose `handle_info/2` has no catch-all. This is a timing-dependent race that surfaced as an intermittent CI crash on OTP 28.

## This change addresses the need by

- Consuming {:tcp,*} / {:ssl,*} transport messages in the :disconnected state instead of forwarding them to the client's handle_info/2.
- Restoring the catch-all handle_info/2 on StatePreservingDisconnectClient.
- Adding a regression test that a stray transport frame in :disconnected is ignored and never reaches the client callback.

Closes #74