### PR TITLE
Emit [:parley, :frame, :sent] on successful send

### DIFF
--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -606,6 +606,7 @@ defmodule Parley.Connection do
       {:ok, websocket, encoded} ->
         case Mint.WebSocket.stream_request_body(data.conn, data.request_ref, encoded) do
           {:ok, conn} ->
+            Parley.Telemetry.frame_sent(frame, data.module, data.uri)
             {:ok, %{data | conn: conn, websocket: websocket}}
 
           {:error, conn, reason} ->

--- a/lib/parley/telemetry.ex
+++ b/lib/parley/telemetry.ex
@@ -26,6 +26,32 @@ defmodule Parley.Telemetry do
       * `:uri` — the `t:URI.t/0` the connection was opened against
       * `:pid` — the connection process that received the frame
 
+  ### `[:parley, :frame, :sent]`
+
+  The send-side twin of `[:parley, :frame, :received]`. Emitted after a
+  frame is successfully handed to the transport, from the single shared
+  send path (a direct `send_frame/2`/`send_frame_async/2`, a `{:push, ...}`
+  callback reply, or an automatic pong answering an inbound ping). Close
+  frames are part of the connection lifecycle rather than data and do
+  **not** emit this event.
+
+  This event is emitted on **success only**: if encoding or the transport
+  send fails, nothing is emitted. In particular a failed automatic pong is
+  silent — the send path swallows the error, so the pong fails without a
+  signal. This is a deliberate trade-off: the delivery signal is delayed,
+  not lost, because a broken transport surfaces on the next inbound
+  message.
+
+    * Measurements
+      * `:size` — the payload size in bytes (`byte_size/1` of the frame
+        payload, not the number of bytes on the wire)
+
+    * Metadata
+      * `:type` — the frame type: `:text`, `:binary`, `:ping`, or `:pong`
+      * `:module` — the module implementing the `Parley` callbacks
+      * `:uri` — the `t:URI.t/0` the connection was opened against
+      * `:pid` — the connection process that sent the frame
+
   ## Example
 
       :telemetry.attach(
@@ -39,6 +65,7 @@ defmodule Parley.Telemetry do
   """
 
   @frame_received [:parley, :frame, :received]
+  @frame_sent [:parley, :frame, :sent]
 
   @doc false
   @spec frame_received(tuple(), module(), URI.t()) :: :ok
@@ -52,4 +79,17 @@ defmodule Parley.Telemetry do
   end
 
   def frame_received(_frame, _module, _uri), do: :ok
+
+  @doc false
+  @spec frame_sent(tuple(), module(), URI.t()) :: :ok
+  def frame_sent({type, payload}, module, %URI{} = uri)
+      when type in [:text, :binary, :ping, :pong] and is_binary(payload) do
+    :telemetry.execute(
+      @frame_sent,
+      %{size: byte_size(payload)},
+      %{type: type, module: module, uri: uri, pid: self()}
+    )
+  end
+
+  def frame_sent(_frame, _module, _uri), do: :ok
 end

--- a/test/parley/telemetry_test.exs
+++ b/test/parley/telemetry_test.exs
@@ -83,6 +83,79 @@ defmodule Parley.TelemetryTest do
     Parley.disconnect(pid)
   end
 
+  test "emits [:parley, :frame, :sent] for a text frame", %{url: url} do
+    ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :frame, :sent]])
+
+    {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+    assert_receive :connected, 1000
+
+    :ok = Parley.send_frame(pid, {:text, "hello"})
+
+    assert_receive {[:parley, :frame, :sent], ^ref, measurements, metadata}, 1000
+
+    # "hello" is 5 bytes; assert the literal, not a recomputation.
+    assert measurements == %{size: 5}
+    assert metadata.type == :text
+    assert metadata.pid == pid
+    assert metadata.module == Client
+    assert metadata.uri == URI.parse(url)
+
+    Parley.disconnect(pid)
+  end
+
+  test "emits [:parley, :frame, :sent] for a binary frame", %{url: url} do
+    ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :frame, :sent]])
+
+    {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+    assert_receive :connected, 1000
+
+    :ok = Parley.send_frame(pid, {:binary, <<1, 2, 3, 4>>})
+
+    assert_receive {[:parley, :frame, :sent], ^ref, measurements, metadata}, 1000
+
+    # <<1, 2, 3, 4>> is 4 bytes; assert the literal, not a recomputation.
+    assert measurements == %{size: 4}
+    assert metadata.type == :binary
+    assert metadata.pid == pid
+    assert metadata.module == Client
+    assert metadata.uri == URI.parse(url)
+
+    Parley.disconnect(pid)
+  end
+
+  test "an inbound ping emits frame:received :ping and the auto-pong emits frame:sent :pong",
+       %{url: url} do
+    ref =
+      :telemetry_test.attach_event_handlers(self(), [
+        [:parley, :frame, :received],
+        [:parley, :frame, :sent]
+      ])
+
+    {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+    assert_receive :connected, 1000
+
+    # Ask the echo server to push us a ping carrying a 3-byte payload. Parley
+    # auto-responds with a pong of the same payload from the shared send path.
+    :ok = Parley.send_frame(pid, {:text, "send_ping:abc"})
+
+    # The inbound ping is data-plane and emits frame:received.
+    assert_receive {[:parley, :frame, :received], ^ref, %{size: 3}, %{type: :ping}}, 1000
+
+    # The auto-pong is the send-side twin and emits frame:sent from
+    # send_frame_internal/2's success branch. "abc" is 3 bytes.
+    assert_receive {[:parley, :frame, :sent], ^ref, received_measurements, received_metadata}
+                   when received_metadata.type == :pong,
+                   1000
+
+    assert received_measurements == %{size: 3}
+    assert received_metadata.type == :pong
+    assert received_metadata.pid == pid
+    assert received_metadata.module == Client
+    assert received_metadata.uri == URI.parse(url)
+
+    Parley.disconnect(pid)
+  end
+
   test "does not emit [:parley, :frame, :received] for a close frame", %{url: url} do
     ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :frame, :received]])
 


### PR DESCRIPTION
## Why

Parley emits `[:parley, :frame, :received]` for inbound frames but has no send-side counterpart, so outbound traffic is invisible to telemetry. With the send paths already unified onto `send_frame_internal/2` (#71), there is a single natural emit site.

## This change addresses the need by

- Adding `Parley.Telemetry.frame_sent/3` (mirroring `frame_received/3`: guarded on `:text`/`:binary`/`:ping`/`:pong` with a binary payload, `:ok` fallback so `:close` and non-binary frames are no-ops), emitting `%{size: byte_size(payload)}` with `%{type, module, uri, pid}`.
- Calling it from `send_frame_internal/2`'s success branch only, so encode/send failures — including failed auto-pongs — emit nothing (the signal is delayed, not lost). This success-only behaviour is documented in the moduledoc.
- Covering `:text`, `:binary`, and the inbound-ping → auto-pong (`frame:received :ping` + `frame:sent :pong`) case with tests.

Part of #61