### PR TITLE
Add [:parley, :connect, :start] / :stop telemetry span

### DIFF
--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -16,6 +16,10 @@ defmodule Parley.Connection do
     :module,
     :user_state,
     :reconnect_timer,
+    # Monotonic time at which the open connect span started. Non-nil means a
+    # [:parley, :connect, :start] has fired without its matching :stop yet, so
+    # it doubles as the open-span flag. Nulled the moment the span is closed.
+    :connect_started_at,
     connect_timeout: @default_connect_timeout,
     headers: [],
     transport_opts: [],
@@ -75,6 +79,12 @@ defmodule Parley.Connection do
   end
 
   def disconnected(:enter, _old_state, data) do
+    # Safety net: any path that reached :disconnected with the span still open
+    # (a {:stop, ...} from a state-enter clause, an unhandled transition) closes
+    # it as :aborted here. Explicit close sites null the flag first, so this
+    # no-ops for them.
+    data = stop_connect_span(data, :aborted, data.disconnect_reason)
+
     if data.conn, do: Mint.HTTP.close(data.conn)
 
     data = %{
@@ -98,13 +108,30 @@ defmodule Parley.Connection do
     end
   end
 
+  # Opening the span and running do_connect are split across two internal
+  # events on purpose: the :start-carrying data must be committed to gen_statem
+  # *before* do_connect runs, so that a raise inside do_connect (e.g.
+  # ws_to_http_scheme/1 on a bad scheme, or Mint.HTTP.connect/4 on bad
+  # transport_opts) still leaves terminate/3 a non-nil connect_started_at to
+  # emit the balancing :stop against.
   def disconnected(:internal, :connect, data) do
+    {:keep_state, start_connect_span(data), [{:next_event, :internal, {:do_connect, :initial}}]}
+  end
+
+  # `origin` distinguishes the two do_connect callers so the error branch keeps
+  # its original behaviour: only the *initial* connect with reconnection disabled
+  # stops the process; a retry (which may be forced by handle_disconnect's
+  # {:reconnect, ...} even when the `reconnect` option is false) always falls
+  # through to :connect_failed.
+  def disconnected(:internal, {:do_connect, origin}, data) do
     case do_connect(data) do
       {:ok, conn, request_ref} ->
         {:next_state, :connecting, %{data | conn: conn, request_ref: request_ref}}
 
       {:error, reason, data} ->
-        if data.reconnect == false do
+        data = stop_connect_span(data, :error, reason)
+
+        if origin == :initial and data.reconnect == false do
           {:stop, {:error, reason}, data}
         else
           {:keep_state, %{data | disconnect_reason: {:error, reason}},
@@ -131,16 +158,11 @@ defmodule Parley.Connection do
     if data.reconnect_timer == nil do
       :keep_state_and_data
     else
-      data = %{data | reconnect_timer: nil}
-
-      case do_connect(data) do
-        {:ok, conn, request_ref} ->
-          {:next_state, :connecting, %{data | conn: conn, request_ref: request_ref}}
-
-        {:error, reason, data} ->
-          {:keep_state, %{data | disconnect_reason: {:error, reason}},
-           [{:next_event, :internal, :connect_failed}]}
-      end
+      # Open the span only once the stale-timer guard has passed, then hand off
+      # to the shared :do_connect handler (see disconnected(:internal, :connect,
+      # ...)) so the same commit-before-connect protection applies here.
+      data = start_connect_span(%{data | reconnect_timer: nil})
+      {:keep_state, data, [{:next_event, :internal, {:do_connect, :reconnect}}]}
     end
   end
 
@@ -197,6 +219,7 @@ defmodule Parley.Connection do
   end
 
   def connecting(:state_timeout, :connect_timeout, data) do
+    data = stop_connect_span(data, :error, :connect_timeout)
     {:next_state, :disconnected, %{data | disconnect_reason: :connect_timeout}}
   end
 
@@ -210,7 +233,8 @@ defmodule Parley.Connection do
         handle_upgrade_responses(%{data | conn: conn}, responses)
 
       {:error, conn, reason, _responses} ->
-        {:next_state, :disconnected, %{data | conn: conn, disconnect_reason: {:error, reason}}}
+        data = stop_connect_span(%{data | conn: conn}, :error, {:error, reason})
+        {:next_state, :disconnected, %{data | disconnect_reason: {:error, reason}}}
 
       :unknown ->
         case data.module.handle_info(message, data.user_state) do
@@ -222,8 +246,9 @@ defmodule Parley.Connection do
             {:keep_state, %{data | user_state: user_state}}
 
           {:disconnect, reason, user_state} ->
-            {:next_state, :disconnected,
-             %{data | user_state: user_state, disconnect_reason: reason}}
+            data = %{data | user_state: user_state, disconnect_reason: reason}
+            data = stop_connect_span(data, :aborted, reason)
+            {:next_state, :disconnected, data}
 
           {:stop, reason, user_state} ->
             if data.conn, do: Mint.HTTP.close(data.conn)
@@ -241,6 +266,7 @@ defmodule Parley.Connection do
   end
 
   def connecting({:call, from}, :disconnect, data) do
+    data = stop_connect_span(data, :aborted, :closed)
     {:next_state, :disconnected, %{data | disconnect_reason: :closed}, [{:reply, from, :ok}]}
   end
 
@@ -355,7 +381,48 @@ defmodule Parley.Connection do
     end
   end
 
+  # Last-resort span close. Runs on every stop, including crashes and shutdowns
+  # (a {:stop, ...} from a state-enter clause hands us the *new* state, so we
+  # never match on state). Emits :aborted only when the span is still open; a
+  # normal close already nulled the flag, making this a no-op.
+  @impl true
+  def terminate(reason, _state, %__MODULE__{} = data) do
+    stop_connect_span(data, :aborted, reason)
+    :ok
+  end
+
+  def terminate(_reason, _state, _data), do: :ok
+
   ## Private helpers
+
+  # Opens the connect span: records the monotonic start time (also the open-span
+  # flag) before emitting, so a slow handler can't inflate the measured
+  # duration, and reads the attempt index straight off the data.
+  defp start_connect_span(data) do
+    data = %{data | connect_started_at: System.monotonic_time()}
+    Parley.Telemetry.connect_start(data.module, data.uri, data.reconnect_attempt)
+    data
+  end
+
+  # Closes the connect span, nulling the flag. Idempotent: a nil flag means the
+  # span is already closed, so repeated closes (explicit site then safety net
+  # then terminate/3) collapse to a single :stop.
+  defp stop_connect_span(%__MODULE__{connect_started_at: nil} = data, _outcome, _reason), do: data
+
+  defp stop_connect_span(%__MODULE__{connect_started_at: started_at} = data, outcome, reason) do
+    duration = System.monotonic_time() - started_at
+
+    Parley.Telemetry.connect_stop(
+      data.module,
+      data.uri,
+      data.reconnect_attempt,
+      duration,
+      outcome,
+      reason
+    )
+
+    %{data | connect_started_at: nil}
+  end
 
   defp parse_reconnect(false), do: false
   defp parse_reconnect(true), do: @default_reconnect_opts
@@ -449,13 +516,18 @@ defmodule Parley.Connection do
       end)
 
     if done?(responses) do
+      # Emit the :stop inside each branch, not before the case: the {:ok, ...}
+      # branch closes the span as :ok while it is still the :connecting state
+      # (attempt not yet reset), and the {:error, ...} branch as :error.
       case Mint.WebSocket.new(data.conn, data.request_ref, data.status, data.resp_headers) do
         {:ok, conn, websocket} ->
-          {:next_state, :connected,
-           %{data | conn: conn, websocket: websocket, status: nil, resp_headers: []}}
+          data = %{data | conn: conn, websocket: websocket, status: nil, resp_headers: []}
+          data = stop_connect_span(data, :ok, nil)
+          {:next_state, :connected, data}
 
         {:error, conn, reason} ->
-          {:next_state, :disconnected, %{data | conn: conn, disconnect_reason: {:error, reason}}}
+          data = stop_connect_span(%{data | conn: conn}, :error, {:error, reason})
+          {:next_state, :disconnected, %{data | disconnect_reason: {:error, reason}}}
       end
     else
       {:keep_state, data}

--- a/lib/parley/telemetry.ex
+++ b/lib/parley/telemetry.ex
@@ -26,6 +26,47 @@ defmodule Parley.Telemetry do
       * `:uri` — the `t:URI.t/0` the connection was opened against
       * `:pid` — the connection process that received the frame
 
+  ### `[:parley, :connect, :start]`
+
+  Emitted when a connection attempt begins, immediately before the
+  synchronous connect runs. Together with `[:parley, :connect, :stop]` it
+  forms a span around every attempt, including reconnect retries.
+
+    * Measurements
+      * `:system_time` — `System.system_time/0` captured when the attempt
+        began
+
+    * Metadata
+      * `:module` — the module implementing the `Parley` callbacks
+      * `:uri` — the `t:URI.t/0` the connection was opened against
+      * `:pid` — the connection process
+      * `:attempt` — the zero-based attempt index: `0` for the initial
+        connect, `N` for the `N`th reconnect retry
+
+  ### `[:parley, :connect, :stop]`
+
+  Emitted when a connection attempt settles, closing the span opened by
+  `[:parley, :connect, :start]`. Every `:start` is paired with exactly one
+  `:stop`.
+
+    * Measurements
+      * `:duration` — native time units elapsed since the matching
+        `:start` (convert with `System.convert_time_unit/3`)
+
+    * Metadata
+      * `:module`, `:uri`, `:pid`, `:attempt` — as in `:start`; `:attempt`
+        matches the paired `:start`
+      * `:outcome` — one of:
+        * `:ok` — the WebSocket upgrade completed and the connection is
+          live
+        * `:error` — the attempt failed (refused, timed out, or the
+          upgrade was rejected); counts toward the connect failure rate
+        * `:aborted` — the attempt was cancelled or the process shut down
+          mid-connect; excluded from the failure rate
+      * `:reason` — `nil` when `outcome` is `:ok`; otherwise the failure
+        term (e.g. `:econnrefused`, `:connect_timeout`, `{:error, term}`,
+        `:closed`, `:shutdown`, or a crash reason)
+
   ## Example
 
       :telemetry.attach(
@@ -39,6 +80,8 @@ defmodule Parley.Telemetry do
   """
 
   @frame_received [:parley, :frame, :received]
+  @connect_start [:parley, :connect, :start]
+  @connect_stop [:parley, :connect, :stop]
 
   @doc false
   @spec frame_received(tuple(), module(), URI.t()) :: :ok
@@ -52,4 +95,41 @@ defmodule Parley.Telemetry do
   end
 
   def frame_received(_frame, _module, _uri), do: :ok
+
+  @doc false
+  @spec connect_start(module(), URI.t(), non_neg_integer()) :: :ok
+  def connect_start(module, %URI{} = uri, attempt)
+      when is_atom(module) and is_integer(attempt) and attempt >= 0 do
+    :telemetry.execute(
+      @connect_start,
+      %{system_time: System.system_time()},
+      %{module: module, uri: uri, pid: self(), attempt: attempt}
+    )
+  end
+
+  @doc false
+  @spec connect_stop(
+          module(),
+          URI.t(),
+          non_neg_integer(),
+          integer(),
+          :ok | :error | :aborted,
+          term()
+        ) :: :ok
+  def connect_stop(module, %URI{} = uri, attempt, duration, outcome, reason)
+      when is_atom(module) and is_integer(attempt) and attempt >= 0 and
+             is_integer(duration) and outcome in [:ok, :error, :aborted] do
+    :telemetry.execute(
+      @connect_stop,
+      %{duration: duration},
+      %{
+        module: module,
+        uri: uri,
+        pid: self(),
+        attempt: attempt,
+        outcome: outcome,
+        reason: reason
+      }
+    )
+  end
 end

--- a/lib/parley/telemetry.ex
+++ b/lib/parley/telemetry.ex
@@ -107,6 +107,8 @@ defmodule Parley.Telemetry do
     )
   end
 
+  def connect_start(_module, _uri, _attempt), do: :ok
+
   @doc false
   @spec connect_stop(
           module(),
@@ -132,4 +134,6 @@ defmodule Parley.Telemetry do
       }
     )
   end
+
+  def connect_stop(_module, _uri, _attempt, _duration, _outcome, _reason), do: :ok
 end

--- a/test/parley/telemetry_test.exs
+++ b/test/parley/telemetry_test.exs
@@ -17,7 +17,7 @@ defmodule Parley.TelemetryTest do
       if Process.alive?(server_pid), do: Supervisor.stop(server_pid, :normal, 1000)
     end)
 
-    %{url: "ws://localhost:#{port}/ws"}
+    %{port: port, url: "ws://localhost:#{port}/ws"}
   end
 
   test "emits [:parley, :frame, :received] for a text frame", %{url: url} do
@@ -97,5 +97,142 @@ defmodule Parley.TelemetryTest do
 
     assert_receive {:disconnected, {:remote_close, 1000, _}}, 1000
     refute_received {[:parley, :frame, :received], ^ref, _measurements, _metadata}
+  end
+
+  describe "connect span" do
+    test "emits :start and an :ok :stop on a successful connect", %{url: url} do
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [
+          [:parley, :connect, :start],
+          [:parley, :connect, :stop]
+        ])
+
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+
+      assert_receive {[:parley, :connect, :start], ^ref, start_measurements, start_metadata}, 1000
+      assert is_integer(start_measurements.system_time)
+      assert start_metadata.module == Client
+      assert start_metadata.uri == URI.parse(url)
+      assert start_metadata.pid == pid
+      assert start_metadata.attempt == 0
+
+      assert_receive {[:parley, :connect, :stop], ^ref, stop_measurements, stop_metadata}, 1000
+      assert is_integer(stop_measurements.duration)
+      assert stop_metadata.module == Client
+      assert stop_metadata.uri == URI.parse(url)
+      assert stop_metadata.pid == pid
+      assert stop_metadata.attempt == 0
+      assert stop_metadata.outcome == :ok
+      assert stop_metadata.reason == nil
+
+      Parley.disconnect(pid)
+    end
+
+    test "emits an :error :stop when the upgrade is rejected", %{port: port} do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :connect, :stop]])
+
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: "ws://localhost:#{port}/reject")
+
+      assert_receive {[:parley, :connect, :stop], ^ref, %{duration: _}, %{outcome: :error}}, 1000
+
+      Parley.disconnect(pid)
+    end
+
+    test "emits an :error :stop when the connection is refused" do
+      Process.flag(:trap_exit, true)
+      ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :connect, :stop]])
+
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: "ws://127.0.0.1:1/ws")
+
+      assert_receive {[:parley, :connect, :stop], ^ref, %{duration: _},
+                      %{outcome: :error, reason: reason}},
+                     1000
+
+      refute reason == nil
+      assert_receive {:EXIT, ^pid, _reason}, 1000
+    end
+
+    test "emits an :error :stop when the connect times out" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :connect, :stop]])
+
+      {port, listener} = EchoServer.black_hole_listen()
+
+      {:ok, pid} =
+        Client.start_link(%{test_pid: self()},
+          url: "ws://127.0.0.1:#{port}/ws",
+          connect_timeout: 100
+        )
+
+      assert_receive {[:parley, :connect, :stop], ^ref, %{duration: _},
+                      %{outcome: :error, reason: :connect_timeout}},
+                     1000
+
+      Parley.disconnect(pid)
+      Process.exit(listener, :kill)
+    end
+
+    test "emits an :aborted :stop when disconnected mid-handshake" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :connect, :stop]])
+
+      {port, listener} = EchoServer.black_hole_listen()
+
+      {:ok, pid} =
+        Client.start_link(%{test_pid: self()},
+          url: "ws://127.0.0.1:#{port}/ws",
+          connect_timeout: 5000
+        )
+
+      :ok = Parley.disconnect(pid)
+
+      assert_receive {[:parley, :connect, :stop], ^ref, %{duration: _}, %{outcome: :aborted}},
+                     1000
+
+      Process.exit(listener, :kill)
+    end
+
+    test "reports attempt > 0 on a :stop after a recovered failure", %{url: url} do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :connect, :stop]])
+
+      {:ok, pid} =
+        Client.start_link(%{test_pid: self()},
+          url: url,
+          reconnect: [base_delay: 10, max_delay: 10]
+        )
+
+      assert_receive :connected, 1000
+      assert_receive {[:parley, :connect, :stop], ^ref, _m, %{outcome: :ok, attempt: 0}}, 1000
+
+      # Kill the server-side socket. The client reconnects; because the attempt
+      # counter only resets *after* a successful connect, the retry's span
+      # carries attempt: 1.
+      :ok = Parley.send_frame(pid, {:text, "crash"})
+      assert_receive {:disconnected, {:error, _}}, 1000
+
+      assert_receive {[:parley, :connect, :stop], ^ref, %{duration: _},
+                      %{outcome: :ok, attempt: 1, reason: nil}},
+                     2000
+    end
+
+    test "emits a balanced start/stop when do_connect raises" do
+      Process.flag(:trap_exit, true)
+
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [
+          [:parley, :connect, :start],
+          [:parley, :connect, :stop]
+        ])
+
+      # scheme "http" hits no ws_to_http_scheme/1 clause, so do_connect raises a
+      # FunctionClauseError mid-run — the span is open with no normal :stop site,
+      # so terminate/3 must emit the balancing :stop.
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: "http://localhost/ws")
+
+      assert_receive {[:parley, :connect, :start], ^ref, %{system_time: _}, %{attempt: 0}}, 1000
+
+      assert_receive {[:parley, :connect, :stop], ^ref, %{duration: _}, %{outcome: :aborted}},
+                     1000
+
+      assert_receive {:EXIT, ^pid, _reason}, 1000
+    end
   end
 end

--- a/test/parley_test.exs
+++ b/test/parley_test.exs
@@ -98,8 +98,7 @@ defmodule ParleyTest do
     end
 
     test "postponed send_frame_async is dropped after connect timeout" do
-      {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
-      {:ok, port} = :inet.port(listen)
+      {port, listener} = EchoServer.black_hole_listen()
 
       {:ok, pid} =
         Client.start_link(%{test_pid: self()},
@@ -115,7 +114,7 @@ defmodule ParleyTest do
       assert_receive {:disconnected, :connect_timeout}, 1000
 
       Parley.disconnect(pid)
-      :gen_tcp.close(listen)
+      Process.exit(listener, :kill)
     end
   end
 
@@ -259,9 +258,7 @@ defmodule ParleyTest do
     end
 
     test "times out when server never completes the upgrade" do
-      # Start a TCP server that accepts connections but never responds
-      {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
-      {:ok, port} = :inet.port(listen)
+      {port, listener} = EchoServer.black_hole_listen()
 
       {:ok, pid} =
         Client.start_link(%{test_pid: self()},
@@ -274,13 +271,11 @@ defmodule ParleyTest do
       # Process stays alive in :disconnected state
       assert Process.alive?(pid)
       Parley.disconnect(pid)
-      :gen_tcp.close(listen)
+      Process.exit(listener, :kill)
     end
 
     test "postponed send_frame gets replied on connect timeout" do
-      # Start a TCP server that accepts connections but never responds
-      {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
-      {:ok, port} = :inet.port(listen)
+      {port, listener} = EchoServer.black_hole_listen()
 
       {:ok, pid} =
         Client.start_link(%{test_pid: self()},
@@ -293,7 +288,7 @@ defmodule ParleyTest do
       assert {:error, :disconnected} = Task.await(task, 1000)
 
       Parley.disconnect(pid)
-      :gen_tcp.close(listen)
+      Process.exit(listener, :kill)
     end
   end
 
@@ -982,9 +977,7 @@ defmodule ParleyTest do
 
   describe "disconnect during connecting" do
     test "disconnect while still in connecting state returns ok" do
-      # Start a TCP server that accepts connections but never responds
-      {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
-      {:ok, port} = :inet.port(listen)
+      {port, listener} = EchoServer.black_hole_listen()
 
       {:ok, pid} =
         Client.start_link(%{test_pid: self()},
@@ -998,7 +991,7 @@ defmodule ParleyTest do
 
       assert Process.alive?(pid)
       Parley.disconnect(pid)
-      :gen_tcp.close(listen)
+      Process.exit(listener, :kill)
     end
   end
 

--- a/test/support/echo_server.ex
+++ b/test/support/echo_server.ex
@@ -112,4 +112,34 @@ defmodule Parley.Test.EchoServer do
     {:ok, {_ip, port}} = ThousandIsland.listener_info(server_pid)
     {port, server_pid}
   end
+
+  @doc """
+  Starts a raw TCP listener that accepts connections but never speaks HTTP.
+
+  The kernel completes the TCP handshake into the listen backlog, so a client
+  connects successfully but never receives a WebSocket upgrade response —
+  driving `connect_timeout`. A Bandit/Plug route can't reproduce this: Bandit
+  finishes the accept before the router runs. Mirrors `start/0`: binds port 0,
+  returns `{port, pid}`, and unlinks the owner so the caller's exit doesn't take
+  it down. Stop it with `Process.exit(pid, :kill)`.
+  """
+  def black_hole_listen do
+    test = self()
+
+    pid =
+      spawn_link(fn ->
+        {:ok, listen} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
+        {:ok, port} = :inet.port(listen)
+        send(test, {self(), port})
+        # Hold the listen socket (and this process) open forever without ever
+        # accepting or responding.
+        Process.sleep(:infinity)
+      end)
+
+    receive do
+      {^pid, port} ->
+        Process.unlink(pid)
+        {port, pid}
+    end
+  end
 end


### PR DESCRIPTION
## Why

Connect attempts are unobservable: there is no way to measure connect duration or failure rate. This is the first telemetry span and introduces the explicit span-tracking mechanism (and `terminate/3`) that the connection span will later extend.

## This change addresses the need by

- Adding `[:parley, :connect, :start]` (`%{system_time}` + `%{module, uri, pid, attempt}`) and `:stop` (`%{duration}` + `%{module, uri, pid, attempt, outcome, reason}`).
- Tracking the span explicitly via a `connect_started_at` struct field that doubles as the open-span flag (non-nil = open, nulled on close); `terminate/3` emits whatever is still open, doing no state matching, so a raise inside `do_connect/1` still balances.
- Splitting connect into a `:connect` then `{:do_connect, origin}` internal event so the span-start commits to state before the synchronous connect runs.
- Setting `outcome` (`:ok` / `:error` / `:aborted`) explicitly at each site — never inferred. Failure rate is countable as `:error` over `:ok + :error`, with cancellations/shutdowns landing in `:aborted`.
- Extracting the inline black-hole `:gen_tcp` listener into `Parley.Test.EchoServer` and covering every outcome (`:ok`; `:error` on reject/refused/timeout; `:aborted` on mid-handshake disconnect; `attempt > 0` after recovery; start/stop balance on a `do_connect` raise).

Part of #61