### PR TITLE
Add [:parley, :reconnect, :scheduled] and :exhausted events

### DIFF
--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -395,16 +395,25 @@ defmodule Parley.Connection do
       max_retries = Keyword.fetch!(reconnect_opts, :max_retries)
 
       if max_retries != :infinity and data.reconnect_attempt >= max_retries do
+        Parley.Telemetry.reconnect_exhausted(data)
         {:stop, {:error, :max_retries_exceeded}, data}
       else
         base_delay = Keyword.fetch!(reconnect_opts, :base_delay)
         max_delay = Keyword.fetch!(reconnect_opts, :max_delay)
+        # calculate_delay/3 gets the PRE-increment attempt so the first retry
+        # is base_delay * 2^0.
         delay = calculate_delay(base_delay, max_delay, data.reconnect_attempt)
 
         timer = Process.send_after(self(), :reconnect, delay)
 
-        {:keep_state,
-         %{data | reconnect_timer: timer, reconnect_attempt: data.reconnect_attempt + 1}}
+        # Increment BEFORE emitting so :scheduled reports the post-increment
+        # attempt (1 for the first retry), aligning it with the connect that
+        # follows. The :reconnect message sits in the mailbox until this
+        # function returns, so the timer cannot race the emit.
+        data = %{data | reconnect_timer: timer, reconnect_attempt: data.reconnect_attempt + 1}
+        Parley.Telemetry.reconnect_scheduled(data, delay)
+
+        {:keep_state, data}
       end
     else
       {:keep_state, data}

--- a/lib/parley/telemetry.ex
+++ b/lib/parley/telemetry.ex
@@ -26,6 +26,56 @@ defmodule Parley.Telemetry do
       * `:uri` — the `t:URI.t/0` the connection was opened against
       * `:pid` — the connection process that received the frame
 
+  ### `[:parley, :reconnect, :scheduled]`
+
+  Emitted when a reconnect attempt has been scheduled after a failed or
+  lost connection, once the backoff timer is armed. Not emitted when
+  reconnection is disabled or suppressed by `c:Parley.handle_disconnect/2`.
+
+    * Measurements
+      * `:delay` — the backoff delay in milliseconds before the retry runs
+
+    * Metadata
+      * `:module` — the module implementing the `Parley` callbacks
+      * `:uri` — the `t:URI.t/0` the connection was opened against
+      * `:pid` — the connection process scheduling the retry
+      * `:attempt` — the retry number, counting from 1 for the first retry.
+        This is the **post-increment** value: it aligns with the `:attempt`
+        carried by the matching connect event, so a `:scheduled` with
+        `attempt: N` pairs with the connect attempt `N` that follows.
+
+  ### `[:parley, :reconnect, :exhausted]`
+
+  Emitted once when the configured `max_retries` is reached and Parley
+  gives up reconnecting, just before the connection process stops. Fires
+  only when `max_retries` is a finite number — never under the default
+  `max_retries: :infinity`.
+
+  This event is the **only** signal that a client has permanently given
+  up: a connection that has exhausted its retries is otherwise
+  indistinguishable from one about to retry. Attach to it to alert on
+  clients that will never come back on their own.
+
+    * Measurements
+      * `:attempt` — the attempt count at exhaustion. Note this is a
+        **measurement**, whereas `:attempt` is *metadata* on every other
+        event. It is a measurement because `Telemetry.Metrics.counter/2`
+        only accounts for an event whose measurement is present — a
+        `%{}`-measurement event is uncountable.
+
+    * Metadata
+      * `:module` — the module implementing the `Parley` callbacks
+      * `:uri` — the `t:URI.t/0` the connection was opened against
+      * `:pid` — the connection process giving up
+
+  > #### Metric choice {: .tip}
+  >
+  > `:attempt` here is always exactly `max_retries` (fixed per
+  > connection; the guard trips at equality), so the intended metric is
+  > `counter("parley.reconnect.exhausted.attempt", tags: [:module])` —
+  > it counts give-ups. A `last_value/2` would graph a flat line and
+  > tell you nothing.
+
   ## Example
 
       :telemetry.attach(
@@ -39,6 +89,8 @@ defmodule Parley.Telemetry do
   """
 
   @frame_received [:parley, :frame, :received]
+  @reconnect_scheduled [:parley, :reconnect, :scheduled]
+  @reconnect_exhausted [:parley, :reconnect, :exhausted]
 
   @doc false
   @spec frame_received(tuple(), module(), URI.t()) :: :ok
@@ -52,4 +104,25 @@ defmodule Parley.Telemetry do
   end
 
   def frame_received(_frame, _module, _uri), do: :ok
+
+  @doc false
+  @spec reconnect_scheduled(map(), non_neg_integer()) :: :ok
+  def reconnect_scheduled(%{module: module, uri: uri, reconnect_attempt: attempt}, delay)
+      when is_integer(delay) do
+    :telemetry.execute(
+      @reconnect_scheduled,
+      %{delay: delay},
+      %{module: module, uri: uri, pid: self(), attempt: attempt}
+    )
+  end
+
+  @doc false
+  @spec reconnect_exhausted(map()) :: :ok
+  def reconnect_exhausted(%{module: module, uri: uri, reconnect_attempt: attempt}) do
+    :telemetry.execute(
+      @reconnect_exhausted,
+      %{attempt: attempt},
+      %{module: module, uri: uri, pid: self()}
+    )
+  end
 end

--- a/test/parley/telemetry_test.exs
+++ b/test/parley/telemetry_test.exs
@@ -98,4 +98,66 @@ defmodule Parley.TelemetryTest do
     assert_receive {:disconnected, {:remote_close, 1000, _}}, 1000
     refute_received {[:parley, :frame, :received], ^ref, _measurements, _metadata}
   end
+
+  test "emits [:parley, :reconnect, :scheduled] with post-increment attempts 1, 2, 3" do
+    # A failed connection with reconnect enabled will EXIT once retries are
+    # exhausted; trap it so the linked test process survives.
+    Process.flag(:trap_exit, true)
+
+    ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :reconnect, :scheduled]])
+
+    # A refused port drives repeated connect failures; each one schedules a
+    # retry. base_delay is tiny so the three retries land quickly.
+    dead_url = "ws://127.0.0.1:1/ws"
+
+    {:ok, pid} =
+      Client.start_link(%{test_pid: self()},
+        url: dead_url,
+        reconnect: [base_delay: 20, max_delay: 100, max_retries: 3]
+      )
+
+    # :scheduled reports the POST-increment attempt, so consecutive events
+    # increase by 1 starting at 1 (not the pre-increment 0, 1, 2).
+    for expected_attempt <- 1..3 do
+      assert_receive {[:parley, :reconnect, :scheduled], ^ref, measurements, metadata}, 2000
+
+      assert metadata.attempt == expected_attempt
+      assert metadata.module == Client
+      assert metadata.uri == URI.parse(dead_url)
+      assert metadata.pid == pid
+
+      # delay is the backoff the retry was scheduled after — a positive integer.
+      assert is_integer(measurements.delay)
+      assert measurements.delay > 0
+    end
+  end
+
+  test "emits [:parley, :reconnect, :exhausted] at the ceiling with attempt == max_retries" do
+    Process.flag(:trap_exit, true)
+
+    ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :reconnect, :exhausted]])
+
+    dead_url = "ws://127.0.0.1:1/ws"
+    max_retries = 3
+
+    {:ok, pid} =
+      Client.start_link(%{test_pid: self()},
+        url: dead_url,
+        reconnect: [base_delay: 20, max_delay: 100, max_retries: max_retries]
+      )
+
+    assert_receive {[:parley, :reconnect, :exhausted], ^ref, measurements, metadata}, 2000
+
+    # attempt is a MEASUREMENT here (metadata everywhere else) and equals
+    # exactly max_retries — the guard trips at equality.
+    assert measurements == %{attempt: max_retries}
+    assert metadata.module == Client
+    assert metadata.uri == URI.parse(dead_url)
+    assert metadata.pid == pid
+    refute Map.has_key?(metadata, :attempt)
+
+    # :exhausted is the only signal for permanently giving up; the process
+    # stops right after.
+    assert_receive {:EXIT, ^pid, {:error, :max_retries_exceeded}}, 2000
+  end
 end


### PR DESCRIPTION
## Why

Automatic reconnection is invisible: there is no signal for a scheduled retry or for permanently giving up. Without an `:exhausted` event, a client that has exhausted its retries looks identical to one about to retry.

## This change addresses the need by

- Adding `[:parley, :reconnect, :scheduled]` (`%{delay}` + `%{module, uri, pid, attempt}`) and `[:parley, :reconnect, :exhausted]` (`%{attempt}` + `%{module, uri, pid}`), both from `maybe_reconnect/2`.
- Moving the `reconnect_attempt` increment before the `:scheduled` emit so it reports the post-increment `attempt` (aligning it with the `connect:start` that follows), while `calculate_delay/3` keeps the pre-increment value so the backoff maths is unchanged.
- Carrying `attempt` as a measurement on `:exhausted` (it is always `max_retries`) so `counter/2` can account for it; the moduledoc documents the counter-vs-`last_value` choice and the give-up rationale.
- Testing the pairing/progression (`:scheduled` attempts 1,2,3…) and that `:exhausted` fires at the ceiling with `attempt == max_retries`.

Part of #61