### PR TITLE
Add [:parley, :connection, :start] / :stop telemetry span

### DIFF
--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -20,6 +20,11 @@ defmodule Parley.Connection do
     # [:parley, :connect, :start] has fired without its matching :stop yet, so
     # it doubles as the open-span flag. Nulled the moment the span is closed.
     :connect_started_at,
+    # Monotonic time at which the connection went live (the :connected
+    # state-enter). Non-nil means a [:parley, :connection, :start] has fired
+    # without its matching :stop yet, so it doubles as the open-span flag for
+    # the connection lifetime span. Nulled the moment that span is closed.
+    :connected_at,
     connect_timeout: @default_connect_timeout,
     headers: [],
     transport_opts: [],
@@ -27,6 +32,13 @@ defmodule Parley.Connection do
     status: nil,
     resp_headers: [],
     disconnect_reason: :closed,
+    # Outcome carried into the connection span's :stop. It is an explicit field,
+    # never inferred from disconnect_reason (which cannot discriminate a real
+    # transport failure from a user-supplied {:error, term}). Defaults to :ok;
+    # set to :error at each transport-error site alongside disconnect_reason,
+    # and reset to :ok wherever disconnect_reason is reset so a past error can't
+    # poison the next connection's span. terminate/3 emits :aborted directly.
+    disconnect_outcome: :ok,
     reconnect: false,
     reconnect_attempt: 0
   ]
@@ -85,6 +97,12 @@ defmodule Parley.Connection do
     # no-ops for them.
     data = stop_connect_span(data, :aborted, data.disconnect_reason)
 
+    # Close the connection lifetime span here, before handle_disconnect/2 runs:
+    # a raise in the user callback would otherwise leak the span. The outcome is
+    # the explicit disconnect_outcome field, never inferred from the reason.
+    # Idempotent, so it no-ops on paths where no live connection was open.
+    data = stop_connection_span(data, data.disconnect_outcome, data.disconnect_reason)
+
     if data.conn, do: Mint.HTTP.close(data.conn)
 
     data = %{
@@ -98,13 +116,20 @@ defmodule Parley.Connection do
 
     case data.module.handle_disconnect(data.disconnect_reason, data.user_state) do
       {:reconnect, user_state} ->
-        maybe_reconnect(:reconnect, %{data | user_state: user_state, disconnect_reason: :closed})
+        maybe_reconnect(
+          :reconnect,
+          %{data | user_state: user_state, disconnect_reason: :closed, disconnect_outcome: :ok}
+        )
 
       {:disconnect, user_state} ->
-        {:keep_state, %{data | user_state: user_state, disconnect_reason: :closed}}
+        {:keep_state,
+         %{data | user_state: user_state, disconnect_reason: :closed, disconnect_outcome: :ok}}
 
       {:ok, user_state} ->
-        maybe_reconnect(:ok, %{data | user_state: user_state, disconnect_reason: :closed})
+        maybe_reconnect(
+          :ok,
+          %{data | user_state: user_state, disconnect_reason: :closed, disconnect_outcome: :ok}
+        )
     end
   end
 
@@ -143,13 +168,20 @@ defmodule Parley.Connection do
   def disconnected(:internal, :connect_failed, data) do
     case data.module.handle_disconnect(data.disconnect_reason, data.user_state) do
       {:reconnect, user_state} ->
-        maybe_reconnect(:reconnect, %{data | user_state: user_state, disconnect_reason: :closed})
+        maybe_reconnect(
+          :reconnect,
+          %{data | user_state: user_state, disconnect_reason: :closed, disconnect_outcome: :ok}
+        )
 
       {:disconnect, user_state} ->
-        {:keep_state, %{data | user_state: user_state, disconnect_reason: :closed}}
+        {:keep_state,
+         %{data | user_state: user_state, disconnect_reason: :closed, disconnect_outcome: :ok}}
 
       {:ok, user_state} ->
-        maybe_reconnect(:ok, %{data | user_state: user_state, disconnect_reason: :closed})
+        maybe_reconnect(
+          :ok,
+          %{data | user_state: user_state, disconnect_reason: :closed, disconnect_outcome: :ok}
+        )
     end
   end
 
@@ -273,6 +305,10 @@ defmodule Parley.Connection do
   ## :connected state
 
   def connected(:enter, :connecting, data) do
+    # The connection is now live: open the connection lifetime span before
+    # running handle_connect, so even an immediate {:stop, ...}/{:disconnect,
+    # ...} from that callback leaves a balancing :stop to fire.
+    data = start_connection_span(data)
     data = %{data | reconnect_attempt: 0, reconnect_timer: nil}
 
     case data.module.handle_connect(data.user_state) do
@@ -291,7 +327,8 @@ defmodule Parley.Connection do
             {:keep_state, data}
 
           {:error, :send, data, reason} ->
-            {:keep_state, %{data | disconnect_reason: {:error, reason}},
+            {:keep_state,
+             %{data | disconnect_reason: {:error, reason}, disconnect_outcome: :error},
              [{:next_event, :internal, :send_failed}]}
         end
 
@@ -327,7 +364,8 @@ defmodule Parley.Connection do
         handle_data_responses(%{data | conn: conn}, responses)
 
       {:error, conn, reason, _responses} ->
-        {:next_state, :disconnected, %{data | conn: conn, disconnect_reason: {:error, reason}}}
+        {:next_state, :disconnected,
+         %{data | conn: conn, disconnect_reason: {:error, reason}, disconnect_outcome: :error}}
 
       :unknown ->
         handle_info_result(data.module.handle_info(message, data.user_state), data)
@@ -343,7 +381,8 @@ defmodule Parley.Connection do
         {:keep_state, data, [{:reply, from, {:error, reason}}]}
 
       {:error, :send, data, reason} ->
-        {:next_state, :disconnected, %{data | disconnect_reason: {:error, reason}},
+        {:next_state, :disconnected,
+         %{data | disconnect_reason: {:error, reason}, disconnect_outcome: :error},
          [{:reply, from, {:error, reason}}]}
     end
   end
@@ -358,7 +397,8 @@ defmodule Parley.Connection do
         {:keep_state, data}
 
       {:error, :send, data, reason} ->
-        {:next_state, :disconnected, %{data | disconnect_reason: {:error, reason}}}
+        {:next_state, :disconnected,
+         %{data | disconnect_reason: {:error, reason}, disconnect_outcome: :error}}
     end
   end
 
@@ -381,13 +421,16 @@ defmodule Parley.Connection do
     end
   end
 
-  # Last-resort span close. Runs on every stop, including crashes and shutdowns
-  # (a {:stop, ...} from a state-enter clause hands us the *new* state, so we
-  # never match on state). Emits :aborted only when the span is still open; a
-  # normal close already nulled the flag, making this a no-op.
+  # Last-resort span close for both spans. Runs on every stop, including crashes
+  # and shutdowns (a {:stop, ...} from a state-enter clause hands us the *new*
+  # state, so we never match on state). Emits :aborted only when a span is still
+  # open; a normal close already nulled its flag, making that close a no-op. A
+  # supervisor shutdown or a callback {:stop, ...} that skips the :disconnected
+  # transition lands here with the connection span still open.
   @impl true
   def terminate(reason, _state, %__MODULE__{} = data) do
-    stop_connect_span(data, :aborted, reason)
+    data = stop_connect_span(data, :aborted, reason)
+    stop_connection_span(data, :aborted, reason)
     :ok
   end
 
@@ -422,6 +465,27 @@ defmodule Parley.Connection do
     )
 
     %{data | connect_started_at: nil}
+  end
+
+  # Opens the connection lifetime span: records the monotonic start time (also
+  # the open-span flag) before emitting, mirroring start_connect_span/1.
+  defp start_connection_span(data) do
+    data = %{data | connected_at: System.monotonic_time()}
+    Parley.Telemetry.connection_start(data.module, data.uri)
+    data
+  end
+
+  # Closes the connection lifetime span, nulling the flag. Idempotent like
+  # stop_connect_span/3: a nil flag means the span is already closed, so the
+  # explicit close site and terminate/3 collapse to a single :stop.
+  defp stop_connection_span(%__MODULE__{connected_at: nil} = data, _outcome, _reason), do: data
+
+  defp stop_connection_span(%__MODULE__{connected_at: started_at} = data, outcome, reason) do
+    duration = System.monotonic_time() - started_at
+
+    Parley.Telemetry.connection_stop(data.module, data.uri, duration, outcome, reason)
+
+    %{data | connected_at: nil}
   end
 
   defp parse_reconnect(false), do: false
@@ -572,7 +636,8 @@ defmodule Parley.Connection do
              %{data | disconnect_reason: {:remote_close, code, reason}}}
 
           {:close_on_send_error, reason, data} ->
-            {:next_state, :disconnected, %{data | disconnect_reason: {:error, reason}}}
+            {:next_state, :disconnected,
+             %{data | disconnect_reason: {:error, reason}, disconnect_outcome: :error}}
 
           {:disconnect, reason, data} ->
             {:next_state, :disconnected, %{data | disconnect_reason: reason}}
@@ -584,7 +649,12 @@ defmodule Parley.Connection do
 
       {:error, websocket, reason} ->
         {:next_state, :disconnected,
-         %{data | websocket: websocket, disconnect_reason: {:error, reason}}}
+         %{
+           data
+           | websocket: websocket,
+             disconnect_reason: {:error, reason},
+             disconnect_outcome: :error
+         }}
     end
   end
 
@@ -656,7 +726,7 @@ defmodule Parley.Connection do
         {:keep_state, data}
 
       {:error, :send, data, reason} ->
-        {:keep_state, %{data | disconnect_reason: {:error, reason}},
+        {:keep_state, %{data | disconnect_reason: {:error, reason}, disconnect_outcome: :error},
          [{:next_event, :internal, :send_failed}]}
     end
   end

--- a/lib/parley/connection.ex
+++ b/lib/parley/connection.ex
@@ -327,9 +327,7 @@ defmodule Parley.Connection do
             {:keep_state, data}
 
           {:error, :send, data, reason} ->
-            {:keep_state,
-             %{data | disconnect_reason: {:error, reason}, disconnect_outcome: :error},
-             [{:next_event, :internal, :send_failed}]}
+            {:keep_state, transport_error(data, reason), [{:next_event, :internal, :send_failed}]}
         end
 
       # Enter callbacks cannot perform state transitions or emit internal
@@ -364,8 +362,7 @@ defmodule Parley.Connection do
         handle_data_responses(%{data | conn: conn}, responses)
 
       {:error, conn, reason, _responses} ->
-        {:next_state, :disconnected,
-         %{data | conn: conn, disconnect_reason: {:error, reason}, disconnect_outcome: :error}}
+        {:next_state, :disconnected, %{transport_error(data, reason) | conn: conn}}
 
       :unknown ->
         handle_info_result(data.module.handle_info(message, data.user_state), data)
@@ -381,8 +378,7 @@ defmodule Parley.Connection do
         {:keep_state, data, [{:reply, from, {:error, reason}}]}
 
       {:error, :send, data, reason} ->
-        {:next_state, :disconnected,
-         %{data | disconnect_reason: {:error, reason}, disconnect_outcome: :error},
+        {:next_state, :disconnected, transport_error(data, reason),
          [{:reply, from, {:error, reason}}]}
     end
   end
@@ -397,8 +393,7 @@ defmodule Parley.Connection do
         {:keep_state, data}
 
       {:error, :send, data, reason} ->
-        {:next_state, :disconnected,
-         %{data | disconnect_reason: {:error, reason}, disconnect_outcome: :error}}
+        {:next_state, :disconnected, transport_error(data, reason)}
     end
   end
 
@@ -486,6 +481,14 @@ defmodule Parley.Connection do
     Parley.Telemetry.connection_stop(data.module, data.uri, duration, outcome, reason)
 
     %{data | connected_at: nil}
+  end
+
+  # Records a transport failure. disconnect_reason and disconnect_outcome must
+  # move together — a reason of {:error, _} always pairs with outcome :error —
+  # so setting both here keeps the two from drifting apart across the error
+  # sites, the way the reconnect resets clear them together.
+  defp transport_error(data, reason) do
+    %{data | disconnect_reason: {:error, reason}, disconnect_outcome: :error}
   end
 
   defp parse_reconnect(false), do: false
@@ -636,8 +639,7 @@ defmodule Parley.Connection do
              %{data | disconnect_reason: {:remote_close, code, reason}}}
 
           {:close_on_send_error, reason, data} ->
-            {:next_state, :disconnected,
-             %{data | disconnect_reason: {:error, reason}, disconnect_outcome: :error}}
+            {:next_state, :disconnected, transport_error(data, reason)}
 
           {:disconnect, reason, data} ->
             {:next_state, :disconnected, %{data | disconnect_reason: reason}}
@@ -648,13 +650,7 @@ defmodule Parley.Connection do
         end
 
       {:error, websocket, reason} ->
-        {:next_state, :disconnected,
-         %{
-           data
-           | websocket: websocket,
-             disconnect_reason: {:error, reason},
-             disconnect_outcome: :error
-         }}
+        {:next_state, :disconnected, %{transport_error(data, reason) | websocket: websocket}}
     end
   end
 
@@ -726,8 +722,7 @@ defmodule Parley.Connection do
         {:keep_state, data}
 
       {:error, :send, data, reason} ->
-        {:keep_state, %{data | disconnect_reason: {:error, reason}, disconnect_outcome: :error},
-         [{:next_event, :internal, :send_failed}]}
+        {:keep_state, transport_error(data, reason), [{:next_event, :internal, :send_failed}]}
     end
   end
 

--- a/lib/parley/telemetry.ex
+++ b/lib/parley/telemetry.ex
@@ -93,6 +93,54 @@ defmodule Parley.Telemetry do
         term (e.g. `:econnrefused`, `:connect_timeout`, `{:error, term}`,
         `:closed`, `:shutdown`, or a crash reason)
 
+  ### `[:parley, :connection, :start]`
+
+  Emitted once the WebSocket upgrade has completed and the connection is
+  live, at the moment it enters the `:connected` state. Together with
+  `[:parley, :connection, :stop]` it forms a span around the whole
+  lifetime of a live connection. This is a different span from
+  `[:parley, :connect, :start]`, which measures a single dial attempt:
+  `:connect` spans one handshake, `:connection` spans everything from the
+  upgrade completing until the connection ends.
+
+    * Measurements
+      * `:system_time` — `System.system_time/0` captured when the
+        connection went live
+
+    * Metadata
+      * `:module` — the module implementing the `Parley` callbacks
+      * `:uri` — the `t:URI.t/0` the connection was opened against
+      * `:pid` — the connection process
+
+  ### `[:parley, :connection, :stop]`
+
+  Emitted when a live connection ends, closing the span opened by
+  `[:parley, :connection, :start]`. Every `:start` is paired with exactly
+  one `:stop`. The `:stop` fires before `c:Parley.handle_disconnect/2`
+  runs, so a raise in that callback cannot leak the span.
+
+    * Measurements
+      * `:duration` — native time units the connection stayed live,
+        elapsed since the matching `:start` (convert with
+        `System.convert_time_unit/3`)
+
+    * Metadata
+      * `:module`, `:uri`, `:pid` — as in `:start`
+      * `:outcome` — one of:
+        * `:ok` — the connection ended cleanly: a local or remote close,
+          or a client-requested disconnect. Any close frame is `:ok` —
+          Parley does not classify close codes, so a peer that sent one
+          spoke the protocol; a client that cares reads `:reason`
+        * `:error` — a transport failure tore the connection down (a lost
+          socket, a failed send, or a decode error)
+        * `:aborted` — the connection process shut down or crashed while
+          still live (e.g. a supervisor shutdown, or a callback returning
+          `{:stop, ...}`)
+      * `:reason` — the termination detail: `:closed`,
+        `{:remote_close, code, text}`, `{:error, term}`, or an exit
+        reason. `:connect_timeout` never appears here — it settles the
+        `:connect` span, before this span opens
+
   ### `[:parley, :reconnect, :scheduled]`
 
   Emitted when a reconnect attempt has been scheduled after a failed or
@@ -159,6 +207,8 @@ defmodule Parley.Telemetry do
   @frame_sent [:parley, :frame, :sent]
   @connect_start [:parley, :connect, :start]
   @connect_stop [:parley, :connect, :stop]
+  @connection_start [:parley, :connection, :start]
+  @connection_stop [:parley, :connection, :stop]
   @reconnect_scheduled [:parley, :reconnect, :scheduled]
   @reconnect_exhausted [:parley, :reconnect, :exhausted]
 
@@ -227,6 +277,31 @@ defmodule Parley.Telemetry do
   end
 
   def connect_stop(_module, _uri, _attempt, _duration, _outcome, _reason), do: :ok
+
+  @doc false
+  @spec connection_start(module(), URI.t()) :: :ok
+  def connection_start(module, %URI{} = uri) when is_atom(module) do
+    :telemetry.execute(
+      @connection_start,
+      %{system_time: System.system_time()},
+      %{module: module, uri: uri, pid: self()}
+    )
+  end
+
+  def connection_start(_module, _uri), do: :ok
+
+  @doc false
+  @spec connection_stop(module(), URI.t(), integer(), :ok | :error | :aborted, term()) :: :ok
+  def connection_stop(module, %URI{} = uri, duration, outcome, reason)
+      when is_atom(module) and is_integer(duration) and outcome in [:ok, :error, :aborted] do
+    :telemetry.execute(
+      @connection_stop,
+      %{duration: duration},
+      %{module: module, uri: uri, pid: self(), outcome: outcome, reason: reason}
+    )
+  end
+
+  def connection_stop(_module, _uri, _duration, _outcome, _reason), do: :ok
 
   @doc false
   @spec reconnect_scheduled(map(), non_neg_integer()) :: :ok

--- a/test/parley/telemetry_test.exs
+++ b/test/parley/telemetry_test.exs
@@ -309,6 +309,156 @@ defmodule Parley.TelemetryTest do
     end
   end
 
+  describe "connection span" do
+    test "emits :start and an :ok :stop on a remote close", %{url: url} do
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [
+          [:parley, :connection, :start],
+          [:parley, :connection, :stop]
+        ])
+
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      assert_receive {[:parley, :connection, :start], ^ref, start_measurements, start_metadata},
+                     1000
+
+      assert is_integer(start_measurements.system_time)
+      assert start_metadata.module == Client
+      assert start_metadata.uri == URI.parse(url)
+      assert start_metadata.pid == pid
+      # The connection span carries no :attempt — that is the connect span's.
+      refute Map.has_key?(start_metadata, :attempt)
+
+      # The echo server answers "close" with a close frame. Any close frame is
+      # :ok — Parley does not classify close codes; the peer spoke the protocol.
+      :ok = Parley.send_frame(pid, {:text, "close"})
+
+      assert_receive {[:parley, :connection, :stop], ^ref, stop_measurements, stop_metadata}, 1000
+      assert is_integer(stop_measurements.duration)
+      assert stop_metadata.module == Client
+      assert stop_metadata.uri == URI.parse(url)
+      assert stop_metadata.pid == pid
+      assert stop_metadata.outcome == :ok
+      assert stop_metadata.reason == {:remote_close, 1000, "normal closure"}
+    end
+
+    test "emits an :error :stop on a transport error", %{url: url} do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :connection, :stop]])
+
+      {:ok, pid} = Client.start_link(%{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      # "crash" kills the server-side socket, tearing the transport down under a
+      # live connection. The outcome is the explicit :error field, not inferred.
+      :ok = Parley.send_frame(pid, {:text, "crash"})
+
+      assert_receive {[:parley, :connection, :stop], ^ref, %{duration: _}, stop_metadata}, 1000
+      assert stop_metadata.outcome == :error
+      assert match?({:error, _}, stop_metadata.reason)
+      assert stop_metadata.module == Client
+      assert stop_metadata.uri == URI.parse(url)
+      assert stop_metadata.pid == pid
+    end
+
+    test "emits an :aborted :stop when shut down by a supervisor", %{url: url} do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:parley, :connection, :stop]])
+
+      # A real supervisor drives terminate/3 via the parent EXIT — a different
+      # mechanism than :gen_statem.stop/1, which reaches terminate/3 through
+      # proc_lib's system message and would go green over a broken path.
+      {:ok, sup} =
+        Supervisor.start_link(
+          [{Client, {%{test_pid: self()}, [url: url]}}],
+          strategy: :one_for_one
+        )
+
+      assert_receive :connected, 1000
+
+      :ok = Supervisor.stop(sup)
+
+      assert_receive {[:parley, :connection, :stop], ^ref, %{duration: _}, %{outcome: :aborted}},
+                     1000
+    end
+
+    test "emits exactly one balanced :start/:stop when a callback returns {:stop, ...}", %{
+      url: url
+    } do
+      Process.flag(:trap_exit, true)
+
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [
+          [:parley, :connection, :start],
+          [:parley, :connection, :stop]
+        ])
+
+      defmodule StopOnFrameClient do
+        use Parley
+
+        @impl true
+        def handle_connect(%{test_pid: pid} = state) do
+          send(pid, :connected)
+          {:ok, state}
+        end
+
+        @impl true
+        def handle_frame({:text, "stop"}, state), do: {:stop, :normal, state}
+        def handle_frame(_frame, state), do: {:ok, state}
+      end
+
+      {:ok, pid} = Parley.start_link(StopOnFrameClient, %{test_pid: self()}, url: url)
+      assert_receive :connected, 1000
+
+      assert_receive {[:parley, :connection, :start], ^ref, _measurements, _metadata}, 1000
+
+      # handle_frame's {:stop, ...} never transitions through :disconnected, so
+      # the disconnected(:enter) :stop site never runs. terminate/3 must emit the
+      # one balancing :stop against the still-open span.
+      :ok = Parley.send_frame(pid, {:text, "stop"})
+
+      assert_receive {[:parley, :connection, :stop], ^ref, %{duration: _}, %{outcome: :aborted}},
+                     1000
+
+      # Exactly one :stop for the one :start — no leaked or duplicated span.
+      refute_receive {[:parley, :connection, :stop], ^ref, _m, _meta}, 200
+      assert_receive {:EXIT, ^pid, :normal}, 1000
+    end
+
+    test "resets the outcome so a clean close after an error reconnect is :ok", %{url: url} do
+      ref =
+        :telemetry_test.attach_event_handlers(self(), [
+          [:parley, :connection, :start],
+          [:parley, :connection, :stop]
+        ])
+
+      {:ok, pid} =
+        Client.start_link(%{test_pid: self()},
+          url: url,
+          reconnect: [base_delay: 10, max_delay: 10]
+        )
+
+      assert_receive :connected, 1000
+      assert_receive {[:parley, :connection, :start], ^ref, _m1, _meta1}, 1000
+
+      # The first span dies from a transport error, carrying outcome: :error.
+      :ok = Parley.send_frame(pid, {:text, "crash"})
+      assert_receive {[:parley, :connection, :stop], ^ref, _m2, %{outcome: :error}}, 1000
+
+      # The reconnect opens a fresh span. Were disconnect_outcome not reset to
+      # :ok when the reconnect cleared disconnect_reason, the poisoned :error
+      # would leak into this second span.
+      assert_receive :connected, 2000
+      assert_receive {[:parley, :connection, :start], ^ref, _m3, _meta3}, 1000
+
+      # A clean remote close on the second span must report :ok — proving the
+      # reset happened, not a lingering field.
+      :ok = Parley.send_frame(pid, {:text, "close"})
+      assert_receive {[:parley, :connection, :stop], ^ref, _m4, %{outcome: :ok}}, 2000
+
+      Parley.disconnect(pid)
+    end
+  end
+
   test "emits [:parley, :reconnect, :scheduled] with post-increment attempts 1, 2, 3" do
     # A failed connection with reconnect enabled will EXIT once retries are
     # exhausted; trap it so the linked test process survives.


### PR DESCRIPTION
Adds the connection **lifetime** span, the last pair of connection-lifecycle
telemetry events. It mirrors the connect-attempt span (#77): `:connect` times a
single dial, `:connection` spans everything from the WebSocket upgrade
completing until the connection ends.

Part of #61.

## Events

- `[:parley, :connection, :start]` — `%{system_time}` + `%{module, uri, pid}`,
  emitted as the process enters `:connected`.
- `[:parley, :connection, :stop]` — `%{duration}` + `%{module, uri, pid,
  outcome, reason}`, emitted when the connection ends, before
  `handle_disconnect/2`.

`outcome` is `:ok` (local/remote close), `:error` (transport failure), or
`:aborted` (shutdown/crash while live). It is an **explicit field**
(`disconnect_outcome`), never inferred from `disconnect_reason` — a client
returning `{:disconnect, {:error, term}, state}` is indistinguishable from a
real transport failure, so inference is unsound. The field resets on reconnect
so a past error can't poison the next connection's span.

## Design

- `connected_at` monotonic field doubles as the open-span flag (non-nil = open,
  nulled on close), exactly like the connect span's `connect_started_at`.
- `terminate/3` is the abrupt-stop safety net, closing the span as `:aborted`
  when it's still open.

## Tests (5, all through the public API + `EchoServer`)

- `:ok` on a remote close.
- `:error` on a transport error (`"crash"`).
- `:aborted` via a **real `Supervisor.stop/1`** (not `:gen_statem.stop/1`, which
  reaches `terminate/3` by a different mechanism and would mask a broken path).
- Exactly one balanced `:start`/`:stop` when a callback returns `{:stop, ...}`.
- Outcome **reset**: an `:error` span then a clean reconnect → the second span
  reports `:ok`, proving the field is reset, not lingering.

`mix test`: 96 tests, 0 failures. `mix format --check-formatted` clean.

## Known limitation (filed as #79)

When a user callback (`handle_connect/1` / `handle_disconnect/2`) **raises**, the
span can leak or double, because `gen_statem` commits an enter callback's data
only on return while `:telemetry.execute` side effects are not rolled back. This
is error-path only, is **pre-existing in the connect span too**, and is outside
this issue's acceptance criteria (all of which pass). Filed as #79 with repro
tests and a fix sketch (defer both callbacks to internal events) rather than
folded in here, since the correct fix is a cross-cutting `gen_statem`
restructure that warrants its own review.
