### PR TITLE
Add cross-cutting telemetry documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Options passed to `Parley.start_link/3` or `Parley.start/3`:
 ### Dependencies
 
 - `mint_web_socket` / `castore` (production)
+- `telemetry` (production) — lifecycle events, see `Parley.Telemetry`
 - `bandit` / `websock_adapter` (test only)
 - `credo` / `dialyxir` (dev/test only)
 

--- a/lib/parley.ex
+++ b/lib/parley.ex
@@ -147,6 +147,14 @@ defmodule Parley do
 
   <div id="parley-demo"></div>
 
+  ## Telemetry
+
+  Parley emits `:telemetry` events across the whole connection lifecycle —
+  frames received and sent, connect attempts, connection lifetime, and
+  reconnects. See `Parley.Telemetry` for the full event reference, a
+  ready-to-attach `:telemetry.attach_many/4` handler with a clause per event,
+  the measurement-unit table, and which metadata is safe to use as metric tags.
+
   ## Callbacks
 
   All callbacks are optional and have default implementations. Override only

--- a/lib/parley/telemetry.ex
+++ b/lib/parley/telemetry.ex
@@ -193,13 +193,13 @@ defmodule Parley.Telemetry do
 
   ## Measurement units
 
-  | Measurement    | Unit             | Emitted on                                 |
-  | -------------- | ---------------- | ------------------------------------------ |
-  | `:size`        | bytes            | `:frame, :received` / `:frame, :sent`      |
-  | `:system_time` | native           | `:connect, :start` / `:connection, :start` |
-  | `:duration`    | native           | `:connect, :stop` / `:connection, :stop`   |
-  | `:delay`       | **milliseconds** | `:reconnect, :scheduled`                   |
-  | `:attempt`     | count            | `:reconnect, :exhausted`                   |
+  | Measurement    | Unit             | Emitted on                                                      |
+  | -------------- | ---------------- | --------------------------------------------------------------- |
+  | `:size`        | bytes            | `[:parley, :frame, :received]`, `[:parley, :frame, :sent]`      |
+  | `:system_time` | native           | `[:parley, :connect, :start]`, `[:parley, :connection, :start]` |
+  | `:duration`    | native           | `[:parley, :connect, :stop]`, `[:parley, :connection, :stop]`   |
+  | `:delay`       | **milliseconds** | `[:parley, :reconnect, :scheduled]`                             |
+  | `:attempt`     | count            | `[:parley, :reconnect, :exhausted]`                             |
 
   > #### `:delay` is milliseconds, not native {: .warning}
   >
@@ -237,11 +237,11 @@ defmodule Parley.Telemetry do
         [:parley, :reconnect, :exhausted]
       ]
 
-      :telemetry.attach_many("my-app-parley", events, &MyApp.Telemetry.handle/4, nil)
+      :telemetry.attach_many("myclient-parley", events, &MyClient.Telemetry.handle/4, nil)
 
   The handler must have a clause for **every** event it attaches:
 
-      defmodule MyApp.Telemetry do
+      defmodule MyClient.Telemetry do
         require Logger
 
         def handle([:parley, :frame, :received], %{size: size}, %{type: type}, _config),
@@ -273,13 +273,14 @@ defmodule Parley.Telemetry do
   >
   > `:telemetry` **detaches a handler that raises** — for *all* the events it
   > was attached to. A missing clause raises `FunctionClauseError` on the first
-  > matching emit, silently killing every metric above. Keep one clause per
-  > event, and avoid a catch-all that could raise on data you did not expect.
+  > matching emit, silently killing every metric above. Avoid a catch-all
+  > clause that could raise on data you did not expect.
 
   ## Metric tags
 
   Metadata drives correlation and tagging, but not every key is safe as a
-  `Telemetry.Metrics` tag — a high-cardinality tag explodes metric storage.
+  [`Telemetry.Metrics`](https://hexdocs.pm/telemetry_metrics) tag — a
+  high-cardinality tag explodes metric storage.
 
   | Metadata   | Safe to tag? | Why                                         |
   | ---------- | ------------ | ------------------------------------------- |
@@ -310,10 +311,9 @@ defmodule Parley.Telemetry do
 
   ## `Telemetry.Metrics`
 
-  A representative config for
-  [`Telemetry.Metrics`](https://hexdocs.pm/telemetry_metrics) — the `counter/2`
-  and `summary/2` helpers come from `import Telemetry.Metrics`, and mind the
-  units from the table above:
+  A representative `Telemetry.Metrics` config — the `counter/2` and `summary/2`
+  helpers come from `import Telemetry.Metrics`, and mind the units from the
+  table above:
 
       import Telemetry.Metrics
 

--- a/lib/parley/telemetry.ex
+++ b/lib/parley/telemetry.ex
@@ -191,7 +191,28 @@ defmodule Parley.Telemetry do
   > it counts give-ups. A `last_value/2` would graph a flat line and
   > tell you nothing.
 
-  ## Example
+  ## Measurement units
+
+  | Measurement    | Unit             | Emitted on                                 |
+  | -------------- | ---------------- | ------------------------------------------ |
+  | `:size`        | bytes            | `:frame, :received` / `:frame, :sent`      |
+  | `:system_time` | native           | `:connect, :start` / `:connection, :start` |
+  | `:duration`    | native           | `:connect, :stop` / `:connection, :stop`   |
+  | `:delay`       | **milliseconds** | `:reconnect, :scheduled`                   |
+  | `:attempt`     | count            | `:reconnect, :exhausted`                   |
+
+  > #### `:delay` is milliseconds, not native {: .warning}
+  >
+  > `:duration` and `:system_time` are `:native` units (convert with
+  > `System.convert_time_unit/3`), but `:delay` is already in milliseconds.
+  > Do **not** configure it as native — a
+  > `summary("parley.reconnect.scheduled.delay", unit: {:native, :millisecond})`
+  > written by analogy with `:duration` silently rescales a value that is
+  > already in ms.
+
+  ## Attaching a handler
+
+  Attach to a single event:
 
       :telemetry.attach(
         "log-received-frames",
@@ -201,6 +222,118 @@ defmodule Parley.Telemetry do
         end,
         nil
       )
+
+  Or attach one handler to the whole feature with
+  `:telemetry.attach_many/4`:
+
+      events = [
+        [:parley, :frame, :received],
+        [:parley, :frame, :sent],
+        [:parley, :connect, :start],
+        [:parley, :connect, :stop],
+        [:parley, :connection, :start],
+        [:parley, :connection, :stop],
+        [:parley, :reconnect, :scheduled],
+        [:parley, :reconnect, :exhausted]
+      ]
+
+      :telemetry.attach_many("my-app-parley", events, &MyApp.Telemetry.handle/4, nil)
+
+  The handler must have a clause for **every** event it attaches:
+
+      defmodule MyApp.Telemetry do
+        require Logger
+
+        def handle([:parley, :frame, :received], %{size: size}, %{type: type}, _config),
+          do: Logger.debug("recv \#{type} \#{size}B")
+
+        def handle([:parley, :frame, :sent], %{size: size}, %{type: type}, _config),
+          do: Logger.debug("sent \#{type} \#{size}B")
+
+        def handle([:parley, :connect, :start], _measurements, %{attempt: attempt}, _config),
+          do: Logger.debug("connect start (attempt \#{attempt})")
+
+        def handle([:parley, :connect, :stop], %{duration: native}, %{outcome: outcome}, _config),
+          do: Logger.debug("connect \#{outcome} in \#{System.convert_time_unit(native, :native, :millisecond)}ms")
+
+        def handle([:parley, :connection, :start], _measurements, _metadata, _config),
+          do: Logger.debug("connection live")
+
+        def handle([:parley, :connection, :stop], %{duration: native}, %{outcome: outcome}, _config),
+          do: Logger.debug("connection ended \#{outcome} after \#{System.convert_time_unit(native, :native, :millisecond)}ms")
+
+        def handle([:parley, :reconnect, :scheduled], %{delay: delay}, %{attempt: attempt}, _config),
+          do: Logger.debug("retry \#{attempt} in \#{delay}ms")
+
+        def handle([:parley, :reconnect, :exhausted], %{attempt: attempt}, _metadata, _config),
+          do: Logger.warning("gave up after \#{attempt} attempts")
+      end
+
+  > #### One clause per attached event {: .warning}
+  >
+  > `:telemetry` **detaches a handler that raises** — for *all* the events it
+  > was attached to. A missing clause raises `FunctionClauseError` on the first
+  > matching emit, silently killing every metric above. Keep one clause per
+  > event, and avoid a catch-all that could raise on data you did not expect.
+
+  ## Metric tags
+
+  Metadata drives correlation and tagging, but not every key is safe as a
+  `Telemetry.Metrics` tag — a high-cardinality tag explodes metric storage.
+
+  | Metadata   | Safe to tag? | Why                                         |
+  | ---------- | ------------ | ------------------------------------------- |
+  | `:outcome` | yes          | small fixed set (`:ok`/`:error`/`:aborted`) |
+  | `:type`    | yes          | frame type atom                             |
+  | `:module`  | yes          | your client module                          |
+  | `:attempt` | yes          | small integer                               |
+  | `uri.host` | yes          | bounded set of hosts                        |
+  | `:reason`  | no           | unbounded error terms                       |
+  | `:uri`     | no           | a struct; tag `uri.host` instead            |
+  | `:pid`     | no           | unbounded and recycled                      |
+
+  `:pid` and `:uri` are in the metadata despite being unsafe to tag: `:module`
+  alone cannot tell apart a pool of connections to the same endpoint, and
+  `:pid` is the only key correlating a `:connect` span to its `:connection`
+  span to the frames on it. Use them in logs and traces, not as metric tags.
+
+  `uri.host` is not itself a metadata key — `Telemetry.Metrics` tags are flat
+  keys (`Map.take/2`), so derive `:host` from `:uri` with `:tag_values`:
+
+      summary("parley.connect.stop.duration",
+        tags: [:host],
+        tag_values: &Map.put(&1, :host, &1.uri.host))
+
+  And note `:attempt` is metadata on the `:connect` events and
+  `:reconnect, :scheduled` (so it can be a tag there), but a **measurement** on
+  `:reconnect, :exhausted` — where it is counted, not tagged.
+
+  ## `Telemetry.Metrics`
+
+  A representative config for
+  [`Telemetry.Metrics`](https://hexdocs.pm/telemetry_metrics) — the `counter/2`
+  and `summary/2` helpers come from `import Telemetry.Metrics`, and mind the
+  units from the table above:
+
+      import Telemetry.Metrics
+
+      [
+        # connect outcomes; the failure rate lives here, split by :outcome
+        counter("parley.connect.stop.duration", tags: [:module, :outcome]),
+        # connect latency, native -> ms
+        summary("parley.connect.stop.duration",
+          unit: {:native, :millisecond}, tags: [:module]),
+        # how long live connections last, native -> ms
+        summary("parley.connection.stop.duration",
+          unit: {:native, :millisecond}, tags: [:module, :outcome]),
+        # permanent give-ups (attempt is a measurement, always == max_retries)
+        counter("parley.reconnect.exhausted.attempt", tags: [:module]),
+        # backoff delay — already ms, no unit conversion
+        summary("parley.reconnect.scheduled.delay", tags: [:module]),
+        # bytes in / out
+        summary("parley.frame.received.size", tags: [:module, :type]),
+        summary("parley.frame.sent.size", tags: [:module, :type])
+      ]
   """
 
   @frame_received [:parley, :frame, :received]


### PR DESCRIPTION
The final piece of the telemetry feature: the cross-cutting documentation that needs all eight events to exist. Per-event docs already landed with each PR; this adds only what can't be written incrementally.

## Adds to `Parley.Telemetry`

- **Measurement-units table** — `duration`/`system_time` native, `delay` **ms**, `size` bytes, `attempt` count, with a warning about the ms-vs-native wart (`delay` is already ms; configuring it as native silently rescales).
- **One `:telemetry.attach_many/4` example** covering all 8 events, with a handler clause **per attached event** — `:telemetry` detaches a handler that raises for *all* its events, so a single missing clause silently kills every metric.
- **Metric-tagging safety table** — safe: `outcome`/`type`/`module`/`attempt`/`uri.host`; never: `reason`/`uri`/`pid`. Includes the `:tag_values` recipe for `uri.host` and why `pid`/`uri` are in the metadata despite being unsafe to tag.
- **A `Telemetry.Metrics` config** (with `import Telemetry.Metrics`) so a user can write a working config from the docs alone.

## Also

- `## Telemetry` pointer in `Parley`'s moduledoc.
- `telemetry` production dependency noted in `AGENTS.md`.

## Verification

`mix docs` clean (no warnings), `mix format --check-formatted` clean, `mix test` 96/0. The `Telemetry.Metrics` config and the `tag_values` recipe were run through the real `telemetry_metrics` package and produce valid metric structs.

Closes #61.
